### PR TITLE
Contacts Widget Live Fix

### DIFF
--- a/PTO-WEB/src/main/resources/templates/application/attorney/AttorneyStart.html
+++ b/PTO-WEB/src/main/resources/templates/application/attorney/AttorneyStart.html
@@ -770,7 +770,6 @@
                                                             </div>
                                                         </span>
                                                     </span>
-                                        </span>
                                     </div><!--END Li's form-group-->
                                     <div class="form-group">
                                         <input class="form-check-input checkmark" type="checkbox" value="" aria-checked="false" tabindex="0" aria-labelledby="notCAList-label" id="notOnCAlist" name="notCAList-checkbox">
@@ -796,7 +795,7 @@
 
                 </div>
             </div>
-            <div class="inlinebuttons btn-group btn-group-justified  owner-paging-buttons" role="nav" aria-label="view previous or next page" id="prevnxt">
+            <div class="inlinebuttons btn-group btn-group-justified  owner-paging-buttons" role="navigation" aria-label="view previous or next page" id="prevnxt">
                 <div class="btn-group">
                     <button type="button" class="btn btn-sm btn-default fill prev" id="prevButton" value="previous">Previous</button>
                 </div>
@@ -813,52 +812,30 @@
             </div>
         </main>
     </div>
-
-
+</div><!--//container fluid-->
+    
     <div class="container-fluid stickycomponents">
         <div id="chats">
             <div class="row">
-
                 <section class="col-xs-12 col-sm-6 col-md-6 col-lg-6 col-sm-offset-6 col-md-offset-6 col-lg-offset-6 weight600" aria-label="your data" id="mydata2">
-
-
-
                     <div class="panel-group">
-
-
-
-
                         <div class="panel panel-default">
-
-
-
-
-
                             <div class="panel-heading" id="contacts">
                                 <h4 class="panel-title">
-                                    <button type="button" class="btn btn-link Accordion-trigger" data-toggle="collapse" data-target="#collapse2" aria-controls="collapse2" aria-expanded="false" id="contactsbtn" aria-label="toggle contacts panel"><span id="toggleglyphone" class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span><span id="toggleglyph" class="glyphicon glyphicon-triangle-top visuallyremoved" aria-hidden="true"></span>Contacts</button>
+                                    <button type="button" class="btn btn-link Accordion-trigger" data-toggle="collapse" data-target="#collapse2" aria-controls="collapse2" aria-expanded="false" id="contactsbtn" aria-label="toggle contacts panel"><span id="toggleglyphone" class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span><span id="toggleglyph" class="glyphicon glyphicon-triangle-top visuallyremoved" aria-hidden="true"></span>  Contacts</button>
                                 </h4>
                                 <button type="button" id="closecontacts" class="close" data-target="#mydata2" aria-label="Close"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></button>
                             </div>
-
-
-
                             <div id="collapse2" class="panel-collapse collapse" aria-labelledby="contactsbtn">
-
-
-
                                 <table class="list-group table-fixed" role="grid" aria-label="contacts">
-
                                     <tbody>
-
-                                    <tr class="row">
+                                    <tr>
                                         <td tabindex="0" class="list-group-item col-xs-6"></td>
                                         <td tabindex="0" class="list-group-item inner-addon right-addon col-xs-6"><i class="glyphicon glyphicon-search" aria-hidden="true"></i><input type="text" class="form-control" id="contactsearch" placeholder="" aria-label="search"></td>
                                     </tr>
-
-                                    <tr class="row">
+                                    <tr>
                                         <td class="nopadding" colspan="2">
-                                            <table class="list-group table" role="grid" id="contactssearch">
+                                            <table class="list-group table" id="contactssearch">
                                                 <thead class="sr-only">
                                                 <tr>
                                                     <th scope="col">Name</th>
@@ -868,67 +845,24 @@
 
                                                 <tbody class="scroll">
                                                 <th:block th:each="contact : ${user.getAttorneyManagedContact()}">
-
-                                                    <tr class="row">
+                                                    <tr>
                                                         <td tabindex="0" class="list-group-item col-xs-6"><a href="#" class="fromcontact" id="managedContactFillFormAction" ><span class="glyphicon glyphicon-plus-sign" role="img" aria-label="select this contact"></span></a> <b th:text="${contact.displayName}">Avo Reed</b></td>
                                                         <td tabindex="0" class="list-group-item col-xs-6" th:text="${contact.email}">avo.reid@us.gt.com</td>
                                                     </tr>
-
                                                 </th:block>
                                                 </tbody>
-
-
                                             </table>
-
-
-
-
                                         </td>
-
                                     </tr>
-
-
-
-
-                                    </tbody>
-
-
-                                </table>
-
-
-
-                            </div>
-
-
-
-
-
+                                </tbody>
+                            </table>
                         </div>
-
-
-
-
-
-                    </div><!--END contacts-->
-
-
-
-
-
-                </section>
-            </div><!--END row-->
-        </div><!--END chats-->
-    </div><!--END div container-fluid-->
-</div><!--END container-fluid-->
-
-
-
-
-
-
-
-
-
+                    </div>
+                </div><!--END contacts-->
+            </section>
+        </div><!--END row-->
+    </div><!--END chats-->
+</div><!--END div container-fluid-->
 
 <!--load model attribute for Jquery consumption  -->
 <script th:inline="javascript">

--- a/PTO-WEB/src/main/resources/templates/application/owner/OwnerStart.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/OwnerStart.html
@@ -232,53 +232,29 @@
             </div>
         </main>
     </div>
-
-
-
-    <div class="container-fluid stickycomponents">
+</div>
+<div class="container-fluid stickycomponents">
         <div id="chats">
             <div class="row">
-
                 <section class="col-xs-12 col-sm-6 col-md-6 col-lg-6 col-sm-offset-6 col-md-offset-6 col-lg-offset-6 weight600" aria-label="your data" id="mydata2">
-
-
-
                     <div class="panel-group">
-
-
-
-
                         <div class="panel panel-default">
-
-
-
-
-
                             <div class="panel-heading" id="contacts">
                                 <h4 class="panel-title">
-                                    <button type="button" class="btn btn-link Accordion-trigger" data-toggle="collapse" data-target="#collapse2" aria-controls="collapse2" aria-expanded="false" id="contactsbtn" aria-label="toggle contacts panel"><span id="toggleglyphone" class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span><span id="toggleglyph" class="glyphicon glyphicon-triangle-top visuallyremoved" aria-hidden="true"></span>Contacts</button>
+                                    <button type="button" class="btn btn-link Accordion-trigger" data-toggle="collapse" data-target="#collapse2" aria-controls="collapse2" aria-expanded="false" id="contactsbtn" aria-label="toggle contacts panel"><span id="toggleglyphone" class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span><span id="toggleglyph" class="glyphicon glyphicon-triangle-top visuallyremoved" aria-hidden="true"></span>  Contacts</button>
                                 </h4>
                                 <button type="button" id="closecontacts" class="close" data-target="#mydata2" aria-label="Close"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></button>
                             </div>
-
-
-
                             <div id="collapse2" class="panel-collapse collapse" aria-labelledby="contactsbtn">
-
-
-
                                 <table class="list-group table-fixed" role="grid" aria-label="contacts">
-
                                     <tbody>
-
-                                    <tr class="row">
+                                    <tr>
                                         <td tabindex="0" class="list-group-item col-xs-6"></td>
                                         <td tabindex="0" class="list-group-item inner-addon right-addon col-xs-6"><i class="glyphicon glyphicon-search" aria-hidden="true"></i><input type="text" class="form-control" id="contactsearch" placeholder="" aria-label="search"></td>
                                     </tr>
-
-                                    <tr class="row">
+                                    <tr>
                                         <td class="nopadding" colspan="2">
-                                            <table class="list-group table" role="grid" id="contactssearch">
+                                            <table class="list-group table" id="contactssearch">
                                                 <thead class="sr-only">
                                                 <tr>
                                                     <th scope="col">Name</th>
@@ -289,57 +265,24 @@
                                                 <tbody class="scroll">
                                                 <th:block th:each="contact : ${user.getOwnerManagedContact()}">
 
-                                                    <tr class="row">
+                                                    <tr>
                                                         <td tabindex="0" class="list-group-item col-xs-6"><a href="#" class="fromcontact" id="managedContactFillFormAction" ><span class="glyphicon glyphicon-plus-sign" role="img" aria-label="select this contact"></span></a> <b th:text="${contact.displayName}">Avo Reed</b></td>
                                                         <td tabindex="0" class="list-group-item col-xs-6" th:text="${contact.email}">avo.reid@us.gt.com</td>
                                                     </tr>
-
                                                 </th:block>
                                                 </tbody>
-
-
                                             </table>
-
-
-
-
                                         </td>
-
                                     </tr>
-
-
-
-
                                     </tbody>
-
-
                                 </table>
-
-
-
                             </div>
-
-
-
-
-
                         </div>
-
-
-
-
-
                     </div><!--END contacts-->
-
-
-
-
-
                 </section>
             </div><!--END row-->
         </div><!--END chats-->
     </div><!--END div container-fluid-->
-</div>
 
 
 <!--load model attribute for Jquery consumption  -->


### PR DESCRIPTION
The problems causing the Contacts Widget to not render were as follows:
1. <tr class = "row"> where, in local files <tr role=“row”>` -- which is actually now unnecessary in this table -- .
2. <div class = "container-fluid"> was inside another <div class = "container-fluid">, in local files, not
3. Text ‘Contacts’ needed space in front of it, in local files, not
4. Extraneous </span>, seemed to not be causing rendering issues in Chrome on PC, fixed, nevertheless