### PR TITLE
Edit Owner Updates

### DIFF
--- a/PTO-WEB/src/main/resources/static/resources/css/lynnstyles.css
+++ b/PTO-WEB/src/main/resources/static/resources/css/lynnstyles.css
@@ -2020,7 +2020,7 @@ button#clearfill, button#clearfillOwnerforeign, button#clearfillOwner {
     box-shadow:         rgb(0,0,0);
     text-shadow: 0 0 0 transparent;
 }
-.resetphonebtn, .resetregbtn, .resetdktrefbtn, .resetnamebtn, .resetportraitbtn, .resetportraitbtn, .resetsignaturebtn, .resettranslationbtn, .resettransliterationbtn, .resetdisclaimbtn, .deleterow, button.resetclassbtn, button.removePartner {
+.resetphonebtn, .resetregbtn, .resetdktrefbtn, .resetnamebtn, .resetportraitbtn, .resetportraitbtn, .resetsignaturebtn, .resettranslationbtn, .resettransliterationbtn, .resetdisclaimbtn, .deleterow, button.resetclassbtn, button.removePartner, button.resetpartner, button.resetpartnerbtn {
     margin: 0 auto;
     float: none;
     margin-top: .545em;
@@ -3413,7 +3413,7 @@ fileholder .linkholder, .fileholder .iconholder{
 #gsselected button.close {
     height:1.4em;
 }
-#editowner button.close, #reviewattorney button.close, #userprofilepage button.close, #yesattorneyfiling button.close, .phones button.close, #detected button.close, #designwithtext button.close, #basisabde button.close, #basisab button.close, button.resetclassbtn, .disclaim button.close, button.removePartner {
+#editowner button.close, #reviewattorney button.close, #userprofilepage button.close, #yesattorneyfiling button.close, .phones button.close, #detected button.close, #designwithtext button.close, #basisabde button.close, #basisab button.close, button.resetclassbtn, .disclaim button.close, button.removePartner, button.resetpartner, button.resetpartnerbtn {
     font-size: 3em;
     height:1.06em;
     color:#009CDE;
@@ -3421,7 +3421,7 @@ fileholder .linkholder, .fileholder .iconholder{
 #dashboardmain button.closegspanels {
 	font-size:3em;
 	}
-#editowner button.close:hover, #reviewattorney button.close:hover, #userprofilepage button.close:hover, #yesattorneyfiling button.close:hover, #detected button.close:hover, #designwithtext button.close:hover, #basisabde button.close:hover, #basisab button.close:hover, #addNewOwnerForm button.close:hover, #addNewOwnerForm button.close:hover, .statementou button.close:hover, button.deleterow:hover, button.resetclassbtn:hover {
+#editowner button.close:hover, #reviewattorney button.close:hover, #userprofilepage button.close:hover, #yesattorneyfiling button.close:hover, #detected button.close:hover, #designwithtext button.close:hover, #basisabde button.close:hover, #basisab button.close:hover, #addNewOwnerForm button.close:hover, #addNewOwnerForm button.close:hover, .statementou button.close:hover, button.deleterow:hover, button.resetclassbtn:hover, .disclaim button.close:hover, button.removePartner:hover, button.resetpartner:hover, button.resetpartnerbtn:hover {
     color: #047db0;
     opacity:1.0;
     -moz-opacity: 1.0;
@@ -3760,7 +3760,7 @@ footer #megamenu ul {
 }
 @media (min-width: 528px) and (max-width:1100px) {
     .breadcrumb-steps p {
-        font-size: .82em;
+        font-size: .8em;
     }
 }
 @media (max-width: 500px){

--- a/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/corp/ownerEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/corp/ownerEdit.html
@@ -384,7 +384,7 @@
                                     </div>
                                 </th:block>
                                 <div class="form-group form-group-md col-xs-6">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" id="additional-name-type"   th:field="${owner.ownerType}">
                                         <option value="">Select</option>
                                         <option value="DBA">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/estate/ownerEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/estate/ownerEdit.html
@@ -132,7 +132,7 @@
                                     </select>
                                 </div>
                                 <div class="form-group form-group-md col-xs-6">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
                                         <option value="Select">Select</option>
                                         <option value="DBA">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/individual/ownerEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/individual/ownerEdit.html
@@ -106,7 +106,7 @@
                                     </select>
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 ">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" name="nameType"   id="additional-name-type"  th:field="${owner.ownerType}"><!--Needs th:attribute-->
                                         <option value="">Select</option>
                                         <option value="dba">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/jointVC/ownerEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/jointVC/ownerEdit.html
@@ -133,7 +133,7 @@
                                     </select>
                                 </div>
                                 <div class="form-group form-group-md col-xs-6">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
                                         <option value="Select">Select</option>
                                         <option value="DBA">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/llc/ownerEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/llc/ownerEdit.html
@@ -132,7 +132,7 @@
                                     </select>
                                 </div>
                                 <div class="form-group form-group-md col-xs-6">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" id="additional-name-type"  th:field="${owner.ownerType}">
                                         <option value="">Select</option>
                                         <option value="DBA">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/llp/ownerEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/llp/ownerEdit.html
@@ -76,7 +76,7 @@
                                         <input type="text" class="form-control"  id="ownername"  th:value="${owner.ownerDisplayname}">
                                     </div>
                                     <div class="form-group form-group-md col-xs-6">
-                                        <label for="stateoforg"><span class="weight600">&#42;</span>State where legally organized <span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
+                                        <label for="stateoforg"><span class="weight600">&#42;</span>State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
                                         <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}" >
                                             <option value="">Select</option>
                                             <option value="Alabama">Alabama</option>
@@ -133,7 +133,7 @@
                                         </select>
                                     </div>
                                     <div class="form-group form-group-md col-xs-6">
-                                        <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                        <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                         <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
                                             <option value="Select">Select</option>
                                             <option value="DBA">Doing Business As (DBA)</option>
@@ -448,7 +448,7 @@
                                             </div>
 
                                             <div class="form-group form-group-md col-xs-6">
-                                                <label><span class="weight600">&#42;</span>State where legally organized</label>
+                                                <label>State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                                 <select class="form-control ge-state" name="State" th:attr="entity-index=${iter.index}" >
                                                     <option  th:value="${exceuter.organizationState}"  th:text="${exceuter.organizationState}"  th:attr="entity-id=${exceuter.id}"selected></option>
                                                     <option value="">Select</option>
@@ -820,7 +820,7 @@
                                                     <input type="text" class="form-control rounded-borders ge-name"  required  value="">
                                                 </div>
                                                 <div class="form-group form-group-md col-xs-6">
-                                                    <label><span class="weight600">&#42;</span>State where legally organized</label>
+                                                    <label>State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                                     <select class="form-control ge-state">
                                                         <option value="">Select</option>
                                                         <option value="Alabama">Alabama</option>

--- a/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/partnership/ownerEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/partnership/ownerEdit.html
@@ -76,7 +76,7 @@
                                         <input type="text" class="form-control"  id="ownername"  th:value="${owner.getOwnerName()}">
                                     </div>
                                     <div class="form-group form-group-md col-xs-6">
-                                        <label for="stateoforg">State where legally organized <span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
+                                        <label for="stateoforg">State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
                                         <select class="form-control" id="stateoforg" th:field="${owner.ownerOrganizationState}" >
                                             <option value="">Select</option>
                                             <option value="United States of America">United States of America</option>
@@ -322,7 +322,7 @@
                                         </select>
                                     </div>
                                     <div class="form-group form-group-md col-xs-6">
-                                        <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                        <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                         <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
                                             <option value="">Select</option>
                                             <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
@@ -636,7 +636,7 @@
                                                 <input type="text" class="form-control rounded-borders ge-name"  style="" th:value="${exceuter.entityName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
                                             </div>
                                             <div class="form-group form-group-md col-xs-6">
-                                                <label><span class="weight600">&#42;</span>State where legally organized</label>
+                                                <label><span class="weight600">&#42;</span>State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
                                                 <select class="form-control ge-state" name="State" th:attr="entity-index=${iter.index}" >
                                                     <option th:value="${exceuter.organizationState}" th:text="${exceuter.organizationState}" th:attr="entity-id=${exceuter.id}"selected></option>
                                                     <option value="">Select</option>
@@ -991,7 +991,7 @@
                                                     <input type="text" class="form-control rounded-borders ge-name"  required  value="">
                                                 </div>
                                                 <div class="form-group form-group-md col-xs-6">
-                                                    <label><span class="weight600">&#42;</span>State where legally organized</label>
+                                                    <label><span class="weight600">&#42;</span>State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
                                                     <select  class="form-control ge-state">
                                                         <option value="">Select</option>
                                                         <option value="Alabama">Alabama</option>

--- a/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/solP/ownerEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/solP/ownerEdit.html
@@ -131,7 +131,7 @@
                                     </select>
                                 </div>
                                 <div class="form-group form-group-md col-xs-6">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" id="additional-name-type"  th:field="${owner.ownerType}">
                                         <option value="">Select</option>
                                         <option value="DBA">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/trust/ownerEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/office_action/optional_actions/owner/trust/ownerEdit.html
@@ -136,7 +136,7 @@
                                     </select>
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-6 col-lg-4">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
                                         <option value="Select">Select</option>
                                         <option value="DBA">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/owner/corp/ownerInfo2.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/corp/ownerInfo2.html
@@ -81,7 +81,7 @@
                                 </select>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                 <select class="form-control" id="additional-name-type" th:field="*{ownerType}">
                                     <option value="">Select</option>
                                     <option value="DBA">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/owner/corp/ownerInfoEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/corp/ownerInfoEdit.html
@@ -7,7 +7,8 @@
     <title>Owner Information</title>
 </head>
 <body>
-<div class="row content"  style="display: none;">
+    <div class="container-fluid">
+        <div class="row content"  style="display: none;">
     <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
         <div class="row" >
             <div class="col-xs-12">
@@ -92,14 +93,14 @@
                         </div>
                         <fieldset aria-labelledby="ownerinfo">
                             <div class="row">
-                                <div class="form-group form-group-md col-xs-6">
+                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
                                     <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
                                     <input type="text" class="form-control"  id="ownername" th:value="${owner.ownerDisplayname}" >
                                 </div>
                                 <th:block th:if="${baseTrademarkApplication.isForeignEnityFiling() == true}">
 
                                     <div class="form-group form-group-md col-xs-6">
-                                        <label for="stateoforg"><span class="weight600">&#42;</span>Country where legally incorporated <span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
+                                        <label for="stateoforg">Country where legally incorporated <span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
                                         <select class="form-control" id="country" th:field="*{owner.ownerOrganizationState}">
                                             <option value="">Select</option>
                                             <option value="United States of America">United States of America</option>
@@ -346,7 +347,7 @@
                                     </div>
                                 </th:block>
                                 <th:block th:if="${baseTrademarkApplication.isForeignEnityFiling() == false}">
-                                    <div class="form-group form-group-md col-xs-6">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
                                         <label for="stateoforg"><span class="weight600">&#42;</span>State of incorporation <span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
                                         <select class="form-control" id="stateoforg" th:field="${owner.ownerOrganizationState}" >
                                             <option value="">Select</option>
@@ -404,8 +405,8 @@
                                         </select>
                                     </div>
                                 </th:block>
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="owner-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                    <label for="owner-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" id="additional-name-type"   th:field="${owner.ownerType}">
                                         <option value="">Select</option>
                                         <option value="DBA">Doing Business As (DBA)</option>
@@ -416,14 +417,14 @@
                                 </div>
 
                                 <th:block  th:if="${owner.isAlternameSet() == true}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype">
                                         <label for="nameoftype">Name</label>
                                         <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
                                     </div>
                                 </th:block>
 
                                 <th:block  th:if="${owner.isAlternameSet() == false}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype" style="display: none;">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype" style="display: none;">
                                         <label for="nameoftype">Name</label>
                                         <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
                                     </div>
@@ -701,18 +702,18 @@
                                     <label for="addressline3">Address line 3</label>
                                     <input type="text" class="form-control" id="addressline3" >
                                 </div>
-                                <div class="form-group form-group-md col-xs-4">
+                                <div class="form-group form-group-md col-xs-12 col-sm-6">
                                     <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
                                     <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}" >
                                 </div>
                                 <th:block th:if="${baseTrademarkApplication.isForeignEnityFiling() == true}">
-                                    <div class="form-group form-group-md col-xs-4">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6">
                                         <label for="ownerState">State/Province/Territory</label>
                                         <input class="form-control" id="ownerState" th:value="${owner.state}" >
                                     </div>
                                 </th:block>
                                 <th:block th:if="${baseTrademarkApplication.isForeignEnityFiling() == false}">
-                                    <div class="form-group form-group-md col-xs-4">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6">
                                         <label for="ownerState">State/Province/Territory</label>
                                         <select class="form-control" id="ownerState" th:field="${owner.state}" required>
                                             <option value="">Select</option>
@@ -770,7 +771,7 @@
                                         </select>
                                     </div>
                                 </th:block>
-                                <div class="form-group form-group-md col-xs-4">
+                                <div class="form-group form-group-md col-xs-12 col-sm-5">
                                     <label for="ownerZipcode">Zip code/Postal code</label>
                                     <input type="text" class="form-control" id="ownerZipcode" placeholder="" th:value="${owner.zipcode}" >
                                 </div>
@@ -830,6 +831,7 @@
         </div>
     </main>
 </div>
+    </div>
 <!--load model attribute for Jquery consumption  -->
 <script th:inline="javascript">
 

--- a/PTO-WEB/src/main/resources/templates/application/owner/corp/ownerInfoForeign.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/corp/ownerInfoForeign.html
@@ -18,12 +18,12 @@
                 <form method="post" id="addNewOwnerForm" action="/owner/add" onsubmit="return validateOwnerForm();" th:object="${addNewOwnerContactFormDTO}" aria-labelledby="ownerinfo">
                     <fieldset aria-labelledby="ownerinfo">
                         <div class="row">
-                            <div class="form-group form-group-md col-xs-12 col-sm-6">
+                            <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
                                 <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
                                 <input type="text" class="form-control"  id="ownername" th:field="*{ownerName}" required>
                             </div>
-                            <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                <label for="additional-name-type">Alternate name: <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                            <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                <label for="additional-name-type">Alternate name: <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                 <select class="form-control" id="additional-name-type" th:field="*{ownerType}">
                                     <option value="">Select</option>
                                     <option value="DBA">Doing Business As (DBA)</option>
@@ -305,15 +305,15 @@
                                 <label for="addressline3">Address line 3</label>
                                 <input type="text" class="form-control" id="addressline3" th:field="*{ownerAddress3}">
                             </div>
-                            <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
+                            <div class="form-group form-group-md col-xs-12 col-sm-6">
                                 <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
                                 <input type="text" class="form-control" id="ownerCity" th:field="*{ownerCity}" required>
                             </div>
-                            <div class="form-group form-group-md col-xs-12 col-md-6 col-lg-4">
+                            <div class="form-group form-group-md col-xs-12 col-sm-6">
                                 <label for="ownerState">State/Province/Territory</label>
                                 <input type="text" class="form-control" id="ownerState" th:field="*{ownerState}">
                             </div>
-                            <div class="form-group form-group-md col-xs-12 col-md-6 col-lg-3">
+                            <div class="form-group form-group-md col-xs-12 col-sm-5">
                                 <label for="ownerZipcode">Zip code/Postal code</label>
                                 <input type="text" class="form-control" id="ownerZipcode" placeholder="" th:field="*{ownerZipcode}" >
                             </div>

--- a/PTO-WEB/src/main/resources/templates/application/owner/estate/ownerInfo.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/estate/ownerInfo.html
@@ -30,7 +30,7 @@
                                 <input type="text" class="form-control"  id="ownername" th:field="*{ownerName}" required>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                <label for="stateoforg">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                <label for="stateoforg">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                 <select class="form-control" id="stateoforg" th:field="*{ownerOrganizationState}" required>
                                     <option value="">Select</option>
                                     <option  value="Alabama">Alabama</option>
@@ -88,7 +88,7 @@
                                 </select>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                 <select class="form-control" id="additional-name-type" th:field="*{ownerType}">
                                     <option value="Select">Select</option>
                                     <option value="DBA">Doing Business As (DBA)</option>
@@ -397,7 +397,7 @@
                                     <input id="partner-owner-name" type="text" th:field="*{partnerDTOs[__${itemStat.index}__].partnerName}"  class="form-control rounded-borders" required>
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="partner-owner-name-state">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label for="partner-owner-name-state">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select  id="partner-owner-name-state" th:field="*{partnerDTOs[__${itemStat.index}__].state}"  class="form-control" name="State"  required>
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>
@@ -453,7 +453,7 @@
                                         <option value="Wyoming">Wyoming</option>
                                     </select>
                                 </div>
-                                <div class="form-group form-group-md col-xs-6">
+                                <div class="form-group form-group-md col-xs-12 col-xs-6">
                                     <label>&#42;>Type</label>
                                     <span>
                                     <select id="partner-owner-name-type" class="form-control partner-owner-name-type" name="nameType" th:field="*{partnerDTOs[__${itemStat.index}__].type}" >
@@ -465,7 +465,7 @@
                                     </select>
                                 </span>
                                 </div>
-                                <div class="form-group form-group-md col-xs-6" id="partner-add-Name-value" style="display: none;">
+                                <div class="form-group form-group-md col-xs-12 col-xs-6" id="partner-add-Name-value" style="display: none;">
                                     <label for="nameoftype">Name</label>
                                     <input type="text" class="form-control" id="partner-add-name" name="nameoftype"  th:field="*{partnerDTOs[__${itemStat.index}__].alternateName}"><!--needs th:attribute-->
                                 </div>
@@ -506,7 +506,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input  class="form-control" id="partner-suffix2" name="suffix"  th:field="*{partner_suffix2}" />
+                                    <input type="text" class="form-control" id="partner-suffix2" name="suffix"  th:field="*{partner_suffix2}" />
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
                                     <label for="partner-citizenship">Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
@@ -763,7 +763,7 @@
                                     <input id="partner-owner-name2" type="text"  class="form-control rounded-borders"  th:field="*{partner_name2}"  >
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="partner-owner-name-state2">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label for="partner-owner-name-state2">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select  id="partner-owner-name-state2"  class="form-control" name="State"  th:field="*{partner_state_org2}"  >
                                         <option  value="">Select</option>
                                         <option  value="Alabama">Alabama</option>
@@ -820,7 +820,7 @@
                                         <option value="N/A">N/A</option>
                                     </select>
                                 </div>
-                                <div class="form-group form-group-md col-xs-6">
+                                <div class="form-group form-group-md col-xs-12 col-xs-6">
                                     <label>&#42;Type</label>
                                     <span>
                                         <select id="partner-owner-name-type2" class="form-control partner-owner-name-type" name="nameType"   th:field="*{partner_alt_type2}">
@@ -832,7 +832,7 @@
                                         </select>
                                      </span>
                                 </div>
-                                <div class="form-group form-group-md col-xs-6" id="partner-add-Name-value2" style="display: none;">
+                                <div class="form-group form-group-md col-xs-12 col-xs-6" id="partner-add-Name-value2" style="display: none;">
                                     <label for="nameoftype">Name</label>
                                     <input type="text" class="form-control" id="partner-add-name2" name="nameoftype"  ><!--needs th:attribute-->
                                 </div>
@@ -872,7 +872,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input  class="form-control" id="partner-suffix3" name="suffix"  th:field="*{partner_suffix3}" />
+                                    <input type="text" class="form-control" id="partner-suffix3" name="suffix" th:field="*{partner_suffix3}" />
 
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
@@ -1126,11 +1126,11 @@
                         <fieldset aria-labelledby="proprietorinfo" id="none-individual-partner-entity3" style="display: none;">
                             <div class="row">
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="ownername"><b style="color: red">&#42;</b>Owner name</label>
+                                    <label for="ownername">&#42;Owner name</label>
                                     <input id="partner-owner-name3" type="text" class="form-control rounded-borders" th:field="*{partner_name3}"  >
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="partner-owner-name-state3">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label for="partner-owner-name-state3">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select id="partner-owner-name-state3" class="form-control" name="State" th:field="*{partner_state_org3}" >
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>
@@ -1188,7 +1188,7 @@
                                     </select>
                                 </div>
 
-                                <div class="form-group form-group-md col-xs-6">
+                                <div class="form-group form-group-md col-xs-12 col-xs-6">
                                     <label>&#42;Type</label>
                                     <span>
                                         <select id="partner-owner-name-type3" class="form-control partner-owner-name-type" name="nameType"   th:field="*{partner_alt_type3}">
@@ -1200,7 +1200,7 @@
                                         </select>
                                     </span>
                                 </div>
-                                <div class="form-group form-group-md col-xs-6" id="partner-add-Name-value3" style="display: none;">
+                                <div class="form-group form-group-md col-xs-12 col-xs-6" id="partner-add-Name-value3" style="display: none;">
                                     <label for="nameoftype">Name</label>
                                     <input type="text" class="form-control" id="partner-add-name3" name="nameoftype"  ><!--needs th:attribute-->
                                 </div>

--- a/PTO-WEB/src/main/resources/templates/application/owner/estate/ownerInfoEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/estate/ownerInfoEdit.html
@@ -7,213 +7,935 @@
     <title>Owner Information</title>
 </head>
 <body>
-<div class="row content"  style="display: none;">
-    <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
-        <div class="row" >
-            <div class="col-xs-12">
-                <!--START Content Div-->
-                <div class="row">
-                    <section class="col-xs-12 steps breadcrumb-steps" aria-label="progress tracker">
-                        <div class="row displaycell">
-                            <div class="col-xs-2 one" id="bs-header1">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>1</span>
+    <div class="container-fluid">
+        <div class="row content"  style="display: none;">
+            <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
+                <div class="row" >
+                    <div class="col-xs-12">
+                        <!--START Content Div-->
+                        <div class="row">
+                            <section class="col-xs-12 steps breadcrumb-steps" aria-label="progress tracker">
+                                <div class="row displaycell">
+                                    <div class="col-xs-2 one" id="bs-header1">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>1</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link1">
+                                                <p class="first">Your details</p>
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link1">
-                                        <p class="first">Your details</p>
+                                    <div class="col-xs-2 two" id="bs-header2">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>2</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link2">
+                                                <p>Trademark details</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 three" id="bs-header3">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>3</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link3">
+                                                <p>Goods and services</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 four" id="bs-header4">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>4</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link4">
+                                                <p>Basis</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 five" id="bs-header5">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>5</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link5">
+                                                <p>Additional info</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 six" id="bs-header6">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>6</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link6">
+                                                <p>Confirm and pay</p>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-xs-2 two" id="bs-header2">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>2</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link2">
-                                        <p>Trademark details</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 three" id="bs-header3">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>3</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link3">
-                                        <p>Goods and services</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 four" id="bs-header4">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>4</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link4">
-                                        <p>Basis</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 five" id="bs-header5">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>5</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link5">
-                                        <p>Additional info</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 six" id="bs-header6">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>6</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link6">
-                                        <p>Confirm and pay</p>
-                                    </div>
-                                </div>
-                            </div>
+                            </section>
                         </div>
-                    </section>
-                </div>
-                <div class="row" style="">
-                    <div class="row">
-                        <div class="col-xs-6">
-                            <h1 style="margin-left: 15px;">Edit Owner Information</h1>
-                        </div>
-                    </div>
-                    <div class="col-xs-12 text-left">
-                        <!--START Owner Information Form-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="ownerinfo">Owner Information</h2>
-                        </div>
-                        <fieldset aria-labelledby="ownerinfo">
+                        <div class="row" style="">
                             <div class="row">
-                                <div class="form-group form-group-md col-xs-12 col-sm-9">
-                                    <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
-                                    <input type="text" class="form-control"  id="ownername"  th:value="${owner.ownerDisplayname}">
+                                <div class="col-xs-6">
+                                    <h1 style="margin-left: 15px;">Edit Owner Information</h1>
                                 </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-9 ">
-                                    <label for="stateoforg"><span class="weight600">&#42;</span>State where legally organized <span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
-                                    <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}" >
-                                        <option value="">Select</option>
-                                        <option value="Alabama">Alabama</option>
-                                        <option value="Alaska">Alaska</option>
-                                        <option value="Arizona">Arizona</option>
-                                        <option value="Arkansas">Arkansas</option>
-                                        <option value="California">California</option>
-                                        <option value="Colorado">Colorado</option>
-                                        <option value="Connecticut">Connecticut</option>
-                                        <option value="Delaware">Delaware</option>
-                                        <option value="District of Columbia">District of Columbia</option>
-                                        <option value="Florida">Florida</option>
-                                        <option value="Georgia">Georgia</option>
-                                        <option value="Hawaii">Hawaii</option>
-                                        <option value="Idaho">Idaho</option>
-                                        <option value="Illinois">Illinois</option>
-                                        <option value="Indiana">Indiana</option>
-                                        <option value="Iowa">Iowa</option>
-                                        <option value="Kansas">Kansas</option>
-                                        <option value="Kentucky">Kentucky</option>
-                                        <option value="Louisiana">Louisiana</option>
-                                        <option value="Maine">Maine</option>
-                                        <option value="Maryland">Maryland</option>
-                                        <option value="Massachusetts">Massachusetts</option>
-                                        <option value="Michigan">Michigan</option>
-                                        <option value="Minnesota">Minnesota</option>
-                                        <option value="Mississippi">Mississippi</option>
-                                        <option value="Missouri">Missouri</option>
-                                        <option value="Montana">Montana</option>
-                                        <option value="Nebraska">Nebraska</option>
-                                        <option value="Nevada">Nevada</option>
-                                        <option value="New Hampshire">New Hampshire</option>
-                                        <option value="New Jersey">New Jersey</option>
-                                        <option value="New Mexico">New Mexico</option>
-                                        <option value="New York">New York</option>
-                                        <option value="North Carolina">North Carolina</option>
-                                        <option value="North Dakota">North Dakota</option>
-                                        <option value="Ohio">Ohio</option>
-                                        <option value="Oklahoma">Oklahoma</option>
-                                        <option value="Oregon">Oregon</option>
-                                        <option value="Pennsylvania">Pennsylvania</option>
-                                        <option value="Rhode Island">Rhode Island</option>
-                                        <option value="South Carolina">South Carolina</option>
-                                        <option value="South Dakota">South Dakota</option>
-                                        <option value="Tennessee">Tennessee</option>
-                                        <option value="Texas">Texas</option>
-                                        <option value="Utah">Utah</option>
-                                        <option value="Vermont">Vermont</option>
-                                        <option value="Virginia">Virginia</option>
-                                        <option value="Washington">Washington</option>
-                                        <option value="West Virginia">West Virginia</option>
-                                        <option value="Wisconsin">Wisconsin</option>
-                                        <option value="Wyoming">Wyoming</option>
-                                    </select>
-                                </div>
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
-                                    <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
-                                        <option value="Select">Select</option>
-                                        <option value="DBA">Doing Business As (DBA)</option>
-                                        <option value="TA">Trading As (TA)</option>
-                                        <option value="AKA">Also Known As (AKA)</option>
-                                        <option value="Formerly">Formerly</option>
-                                    </select>
-                                </div>
-
-                                <th:block  th:if="${owner.isAlternameSet() == true}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype">
-                                        <label for="nameoftype">Name</label>
-                                        <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
-                                    </div>
-                                </th:block>
-
-                                <th:block  th:if="${owner.isAlternameSet() == false}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype" style="display: none;">
-                                        <label for="nameoftype">Name</label>
-                                        <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
-                                    </div>
-                                </th:block>
-
-
                             </div>
-                        </fieldset>
-                        <!--END Owner Information-->
-                        <!--START Sole Proprietor Information-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="proprietorinfo">Executor Information</h2>
-                        </div>
-                        <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity" style="">
-                            <th:block th:each="exceuter, iter : ${governingEntity}">
-                                <div class="row">
-                                    <th:block th:if="${exceuter.isPrimaryGoverningEntity() == false}">
-                                        <div class="form-group form-group-md col-xs-12 removepartner">
-                                            <button type="button" class="btn btn-sm close removepartner" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
+                            <div class="col-xs-12 text-left">
+                                <!--START Owner Information Form-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="ownerinfo">Owner Information</h2>
+                                </div>
+                                <fieldset aria-labelledby="ownerinfo">
+                                    <div class="row">
+                                        <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                            <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
+                                            <input type="text" class="form-control"  id="ownername"  th:value="${owner.ownerDisplayname}">
                                         </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                            <label for="stateoforg">State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
+                                            <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}" >
+                                                <option value="">Select</option>
+                                                <option value="Alabama">Alabama</option>
+                                                <option value="Alaska">Alaska</option>
+                                                <option value="Arizona">Arizona</option>
+                                                <option value="Arkansas">Arkansas</option>
+                                                <option value="California">California</option>
+                                                <option value="Colorado">Colorado</option>
+                                                <option value="Connecticut">Connecticut</option>
+                                                <option value="Delaware">Delaware</option>
+                                                <option value="District of Columbia">District of Columbia</option>
+                                                <option value="Florida">Florida</option>
+                                                <option value="Georgia">Georgia</option>
+                                                <option value="Hawaii">Hawaii</option>
+                                                <option value="Idaho">Idaho</option>
+                                                <option value="Illinois">Illinois</option>
+                                                <option value="Indiana">Indiana</option>
+                                                <option value="Iowa">Iowa</option>
+                                                <option value="Kansas">Kansas</option>
+                                                <option value="Kentucky">Kentucky</option>
+                                                <option value="Louisiana">Louisiana</option>
+                                                <option value="Maine">Maine</option>
+                                                <option value="Maryland">Maryland</option>
+                                                <option value="Massachusetts">Massachusetts</option>
+                                                <option value="Michigan">Michigan</option>
+                                                <option value="Minnesota">Minnesota</option>
+                                                <option value="Mississippi">Mississippi</option>
+                                                <option value="Missouri">Missouri</option>
+                                                <option value="Montana">Montana</option>
+                                                <option value="Nebraska">Nebraska</option>
+                                                <option value="Nevada">Nevada</option>
+                                                <option value="New Hampshire">New Hampshire</option>
+                                                <option value="New Jersey">New Jersey</option>
+                                                <option value="New Mexico">New Mexico</option>
+                                                <option value="New York">New York</option>
+                                                <option value="North Carolina">North Carolina</option>
+                                                <option value="North Dakota">North Dakota</option>
+                                                <option value="Ohio">Ohio</option>
+                                                <option value="Oklahoma">Oklahoma</option>
+                                                <option value="Oregon">Oregon</option>
+                                                <option value="Pennsylvania">Pennsylvania</option>
+                                                <option value="Rhode Island">Rhode Island</option>
+                                                <option value="South Carolina">South Carolina</option>
+                                                <option value="South Dakota">South Dakota</option>
+                                                <option value="Tennessee">Tennessee</option>
+                                                <option value="Texas">Texas</option>
+                                                <option value="Utah">Utah</option>
+                                                <option value="Vermont">Vermont</option>
+                                                <option value="Virginia">Virginia</option>
+                                                <option value="Washington">Washington</option>
+                                                <option value="West Virginia">West Virginia</option>
+                                                <option value="Wisconsin">Wisconsin</option>
+                                                <option value="Wyoming">Wyoming</option>
+                                            </select>
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                            <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                            <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
+                                                <option value="Select">Select</option>
+                                                <option value="DBA">Doing Business As (DBA)</option>
+                                                <option value="TA">Trading As (TA)</option>
+                                                <option value="AKA">Also Known As (AKA)</option>
+                                                <option value="Formerly">Formerly</option>
+                                            </select>
+                                        </div>
+
+                                        <th:block  th:if="${owner.isAlternameSet() == true}">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype">
+                                                <label for="nameoftype">Name</label>
+                                                <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
+                                            </div>
+                                        </th:block>
+
+                                        <th:block  th:if="${owner.isAlternameSet() == false}">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype" style="display: none;">
+                                                <label for="nameoftype">Name</label>
+                                                <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
+                                            </div>
+                                        </th:block>
+
+
+                                    </div>
+                                </fieldset>
+                                <!--END Owner Information-->
+                                <!--START Sole Proprietor Information-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="proprietorinfo">Executor Information</h2>
+                                </div>
+                                <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity" style="">
+                                    <th:block th:each="exceuter, iter : ${governingEntity}">
+                                        <div class="row">
+                                            <th:block th:if="${exceuter.isPrimaryGoverningEntity() == false}">
+                                                <div class="form-group form-group-md col-xs-12 removepartner">
+                                                    <button type="button" class="btn btn-sm close removepartner" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
+                                                </div>
+                                            </th:block>
+                                            <th:block th:if="${exceuter.isPersonEntity() == true}">
+                                                <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
+                                                    <label ><span class="weight600">&#42;</span>First name</label>
+                                                    <input type="text"  name="firstName" class="form-control ge-first-name" th:value="${exceuter.firstName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}" >
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
+                                                    <label >Middle name</label>
+                                                    <input type="text"  name="middleName" class="form-control ge-middle-name" th:value="${exceuter.middleName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
+                                                    <label ><span class="weight600">&#42;</span>Last name</label>
+                                                    <input  type="text"  name="lastName" class="form-control ge-last-name" th:value="${exceuter.lastName}"   th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
+                                                    <label>Suffix</label>
+                                                    <input type="text" class="form-control ge-suffix"  name="suffix" />
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
+                                                    <label>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                                    <select class="form-control ge-citizenship" name="owner-citizenship" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                        <option th:value="${exceuter.entityCitizenship}"  th:text="${exceuter.entityCitizenship}" selected  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"></option>
+                                                        <option value="">Select</option>
+                                                        <option value="United States of America">United States of America</option>
+                                                        <option value="Afghanistan">Afghanistan</option>
+                                                        <option value="Albania">Albania</option>
+                                                        <option value="Algeria">Algeria</option>
+                                                        <option value="American Samoa">American Samoa</option>
+                                                        <option value="Andorra">Andorra</option>
+                                                        <option value="Angola">Angola</option>
+                                                        <option value="Anguilla">Anguilla</option>
+                                                        <option value="Antarctica">Antarctica</option>
+                                                        <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+                                                        <option value="Argentina">Argentina</option>
+                                                        <option value="Armenia">Armenia</option>
+                                                        <option value="Aruba">Aruba</option>
+                                                        <option value="Australia">Australia</option>
+                                                        <option value="Austria">Austria</option>
+                                                        <option value="Azerbaijan">Azerbaijan</option>
+                                                        <option value="Bahamas">Bahamas</option>
+                                                        <option value="Bahrain">Bahrain</option>
+                                                        <option value="Bangladesh">Bangladesh</option>
+                                                        <option value="Barbados">Barbados</option>
+                                                        <option value="Belarus">Belarus</option>
+                                                        <option value="Belgium">Belgium</option>
+                                                        <option value="Belize">Belize</option>
+                                                        <option value="Benin">Benin</option>
+                                                        <option value="Bermuda">Bermuda</option>
+                                                        <option value="Bhutan">Bhutan</option>
+                                                        <option value="Bolivia">Bolivia</option>
+                                                        <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+                                                        <option value="Botswana">Botswana</option>
+                                                        <option value="Bouvet Island">Bouvet Island</option>
+                                                        <option value="Brazil">Brazil</option>
+                                                        <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+                                                        <option value="Brunei Darussalam">Brunei Darussalam</option>
+                                                        <option value="Bulgaria">Bulgaria</option>
+                                                        <option value="Burkina Faso">Burkina Faso</option>
+                                                        <option value="Burundi">Burundi</option>
+                                                        <option value="Canada">Canada</option>
+                                                        <option value="Cambodia">Cambodia</option>
+                                                        <option value="Cameroon">Cameroon</option>
+                                                        <option value="Cape Verde">Cape Verde</option>
+                                                        <option value="Cayman Islands">Cayman Islands</option>
+                                                        <option value="Central African Republic">Central African Republic</option>
+                                                        <option value="Chad">Chad</option>
+                                                        <option value="Chile">Chile</option>
+                                                        <option value="China">China</option>
+                                                        <option value="Christmas Island">Christmas Island</option>
+                                                        <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+                                                        <option value="Colombia">Colombia</option>
+                                                        <option value="Comoros">Comoros</option>
+                                                        <option value="Congo">Congo</option>
+                                                        <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
+                                                        <option value="Cook Islands">Cook Islands</option>
+                                                        <option value="Costa Rica">Costa Rica</option>
+                                                        <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
+                                                        <option value="Croatia">Croatia</option>
+                                                        <option value="Cuba">Cuba</option>
+                                                        <option value="Cyprus">Cyprus</option>
+                                                        <option value="Czech Republic">Czech Republic</option>
+                                                        <option value="Denmark">Denmark</option>
+                                                        <option value="Djibouti">Djibouti</option>
+                                                        <option value="Dominica">Dominica</option>
+                                                        <option value="Dominican Republic">Dominican Republic</option>
+                                                        <option value="East Timor">East Timor</option>
+                                                        <option value="Ecuador">Ecuador</option>
+                                                        <option value="Egypt">Egypt</option>
+                                                        <option value="El Salvador">El Salvador</option>
+                                                        <option value="Equatorial Guinea">Equatorial Guinea</option>
+                                                        <option value="Eritrea">Eritrea</option>
+                                                        <option value="Estonia">Estonia</option>
+                                                        <option value="Ethiopia">Ethiopia</option>
+                                                        <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+                                                        <option value="Faroe Islands">Faroe Islands</option>
+                                                        <option value="Fiji">Fiji</option>
+                                                        <option value="Finland">Finland</option>
+                                                        <option value="France">France</option>
+                                                        <option value="French Guiana">French Guiana</option>
+                                                        <option value="French Polynesia">French Polynesia</option>
+                                                        <option value="French Southern Territories">French Southern Territories</option>
+                                                        <option value="Gabon">Gabon</option>
+                                                        <option value="Gambia">Gambia</option>
+                                                        <option value="Georgia">Georgia</option>
+                                                        <option value="Germany">Germany</option>
+                                                        <option value="Ghana">Ghana</option>
+                                                        <option value="Gibraltar">Gibraltar</option>
+                                                        <option value="Greece">Greece</option>
+                                                        <option value="Greenland">Greenland</option>
+                                                        <option value="Grenada">Grenada</option>
+                                                        <option value="Guadeloupe">Guadeloupe</option>
+                                                        <option value="Guam">Guam</option>
+                                                        <option value="Guatemala">Guatemala</option>
+                                                        <option value="Guinea">Guinea</option>
+                                                        <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
+                                                        <option value="Guyana">Guyana</option>
+                                                        <option value="Haiti">Haiti</option>
+                                                        <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+                                                        <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+                                                        <option value="Honduras">Honduras</option>
+                                                        <option value="Hong Kong">Hong Kong</option>
+                                                        <option value="Hungary">Hungary</option>
+                                                        <option value="Iceland">Iceland</option>
+                                                        <option value="India">India</option>
+                                                        <option value="Indonesia">Indonesia</option>
+                                                        <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+                                                        <option value="Iraq">Iraq</option>
+                                                        <option value="Ireland">Ireland</option>
+                                                        <option value="Israel">Israel</option>
+                                                        <option value="Italy">Italy</option>
+                                                        <option value="Jamaica">Jamaica</option>
+                                                        <option value="Japan">Japan</option>
+                                                        <option value="Jordan">Jordan</option>
+                                                        <option value="Kazakstan">Kazakstan</option>
+                                                        <option value="Kenya">Kenya</option>
+                                                        <option value="Kiribati">Kiribati</option>
+                                                        <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
+                                                        <option value="Korea, Republic of">Korea, Republic of</option>
+                                                        <option value="Kuwait">Kuwait</option>
+                                                        <option value="Kyrgyzstan">Kyrgyzstan</option>
+                                                        <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
+                                                        <option value="Latvia">Latvia</option>
+                                                        <option value="Lebanon">Lebanon</option>
+                                                        <option value="Lesotho">Lesotho</option>
+                                                        <option value="Liberia">Liberia</option>
+                                                        <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
+                                                        <option value="Liechtenstein">Liechtenstein</option>
+                                                        <option value="Lithuania">Lithuania</option>
+                                                        <option value="Luxembourg">Luxembourg</option>
+                                                        <option value="Macau">Macau</option>
+                                                        <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
+                                                        <option value="Madagascar">Madagascar</option>
+                                                        <option value="Malawi">Malawi</option>
+                                                        <option value="Malaysia">Malaysia</option>
+                                                        <option value="Maldives">Maldives</option>
+                                                        <option value="Mali">Mali</option>
+                                                        <option value="Malta">Malta</option>
+                                                        <option value="Marshall Islands">Marshall Islands</option>
+                                                        <option value="Martinique">Martinique</option>
+                                                        <option value="Mauritania">Mauritania</option>
+                                                        <option value="Mauritius">Mauritius</option>
+                                                        <option value="Mayotte">Mayotte</option>
+                                                        <option value="Mexico">Mexico</option>
+                                                        <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+                                                        <option value="Moldova, Republic of">Moldova, Republic of</option>
+                                                        <option value="Monaco">Monaco</option>
+                                                        <option value="Mongolia">Mongolia</option>
+                                                        <option value="Montserrat">Montserrat</option>
+                                                        <option value="Morocco">Morocco</option>
+                                                        <option value="Mozambique">Mozambique</option>
+                                                        <option value="Myanmar">Myanmar</option>
+                                                        <option value="Namibia">Namibia</option>
+                                                        <option value="Nauru">Nauru</option>
+                                                        <option value="Nepal">Nepal</option>
+                                                        <option value="Netherlands">Netherlands</option>
+                                                        <option value="Netherlands Antilles">Netherlands Antilles</option>
+                                                        <option value="New Caledonia">New Caledonia</option>
+                                                        <option value="New Zealand">New Zealand</option>
+                                                        <option value="Nicaragua">Nicaragua</option>
+                                                        <option value="Niger">Niger</option>
+                                                        <option value="Nigeria">Nigeria</option>
+                                                        <option value="Niue">Niue</option>
+                                                        <option value="Norfolk Island">Norfolk Island</option>
+                                                        <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+                                                        <option value="Norway">Norway</option>
+                                                        <option value="Oman">Oman</option>
+                                                        <option value="Pakistan">Pakistan</option>
+                                                        <option value="Palau">Palau</option>
+                                                        <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+                                                        <option value="Panama">Panama</option>
+                                                        <option value="Papua New Guinea">Papua New Guinea</option>
+                                                        <option value="Paraguay">Paraguay</option>
+                                                        <option value="Peru">Peru</option>
+                                                        <option value="Philippines">Philippines</option>
+                                                        <option value="Pitcairn">Pitcairn</option>
+                                                        <option value="Poland">Poland</option>
+                                                        <option value="Portugal">Portugal</option>
+                                                        <option value="Puerto Rico">Puerto Rico</option>
+                                                        <option value="Qatar">Qatar</option>
+                                                        <option value="Reunion">Reunion</option>
+                                                        <option value="Romania">Romania</option>
+                                                        <option value="Russian Federation">Russian Federation</option>
+                                                        <option value="Rwanda">Rwanda</option>
+                                                        <option value="Saint Helena">Saint Helena</option>
+                                                        <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+                                                        <option value="Saint Lucia">Saint Lucia</option>
+                                                        <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+                                                        <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
+                                                        <option value="Samoa">Samoa</option>
+                                                        <option value="San Marino">San Marino</option>
+                                                        <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+                                                        <option value="Saudi Arabia">Saudi Arabia</option>
+                                                        <option value="Senegal">Senegal</option>
+                                                        <option value="Seychelles">Seychelles</option>
+                                                        <option value="Sierra Leone">Sierra Leone</option>
+                                                        <option value="Singapore">Singapore</option>
+                                                        <option value="Slovakia">Slovakia</option>
+                                                        <option value="Slovenia">Slovenia</option>
+                                                        <option value="Solomon Islands">Solomon Islands</option>
+                                                        <option value="Somalia">Somalia</option>
+                                                        <option value="South Africa">South Africa</option>
+                                                        <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
+                                                        <option value="Spain">Spain</option>
+                                                        <option value="Sri Lanka">Sri Lanka</option>
+                                                        <option value="Sudan">Sudan</option>
+                                                        <option value="Suriname">Suriname</option>
+                                                        <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+                                                        <option value="Swaziland">Swaziland</option>
+                                                        <option value="Sweden">Sweden</option>
+                                                        <option value="Switzerland">Switzerland</option>
+                                                        <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+                                                        <option value="Taiwan">Taiwan</option>
+                                                        <option value="Tajikistan">Tajikistan</option>
+                                                        <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+                                                        <option value="Thailand">Thailand</option>
+                                                        <option value="Togo">Togo</option>
+                                                        <option value="Tokelau">Tokelau</option>
+                                                        <option value="Tonga">Tonga</option>
+                                                        <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+                                                        <option value="Tunisia">Tunisia</option>
+                                                        <option value="Turkey">Turkey</option>
+                                                        <option value="Turkmenistan">Turkmenistan</option>
+                                                        <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+                                                        <option value="Tuvalu">Tuvalu</option>
+                                                        <option value="Uganda">Uganda</option>
+                                                        <option value="Ukraine">Ukraine</option>
+                                                        <option value="United Arab Emirates">United Arab Emirates</option>
+                                                        <option value="United Kingdom">United Kingdom</option>
+                                                        <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+                                                        <option value="Uruguay">Uruguay</option>
+                                                        <option value="Uzbekistan">Uzbekistan</option>
+                                                        <option value="Vanuatu">Vanuatu</option>
+                                                        <option value="Venezuela">Venezuela</option>
+                                                        <option value="Viet Nam">Viet Nam</option>
+                                                        <option value="Virgin Islands, British">Virgin Islands, British</option>
+                                                        <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+                                                        <option value="Wallis and Futuna">Wallis and Futuna</option>
+                                                        <option value="Western Sahara">Western Sahara</option>
+                                                        <option value="Yemen">Yemen</option>
+                                                        <option value="Yugoslavia">Yugoslavia</option>
+                                                        <option value="Zambia">Zambia</option>
+                                                        <option value="Zimbabwe">Zimbabwe</option>
+                                                        <option value="Unknown">Unknown</option>
+                                                    </select>
+                                                </div>
+                                            </th:block>
+                                            <th:block th:if="${exceuter.isPersonEntity() == false}">
+                                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                    <label><span class="weight600">&#42;</span>Owner name</label>
+                                                    <input  type="text" class="form-control rounded-borders ge-name"  style="" th:value="${exceuter.entityName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                    <label>State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
+                                                    <select class="form-control ge-state" name="State" th:attr="entity-index=${iter.index}" >
+                                                        <option th:value="${exceuter.organizationState}" th:text="${exceuter.organizationState}"  th:attr="entity-id=${exceuter.id}"selected></option>
+                                                        <option value="">Select</option>
+                                                        <option value="Alabama">Alabama</option>
+                                                        <option value="Alaska">Alaska</option>
+                                                        <option value="Arizona">Arizona</option>
+                                                        <option value="Arkansas">Arkansas</option>
+                                                        <option value="California">California</option>
+                                                        <option value="Colorado">Colorado</option>
+                                                        <option value="Connecticut">Connecticut</option>
+                                                        <option value="Delaware">Delaware</option>
+                                                        <option value="District of Columbia">District of Columbia</option>
+                                                        <option value="Florida">Florida</option>
+                                                        <option value="Georgia">Georgia</option>
+                                                        <option value="Hawaii">Hawaii</option>
+                                                        <option value="Idaho">Idaho</option>
+                                                        <option value="Illinois">Illinois</option>
+                                                        <option value="Indiana">Indiana</option>
+                                                        <option value="Iowa">Iowa</option>
+                                                        <option value="Kansas">Kansas</option>
+                                                        <option value="Kentucky">Kentucky</option>
+                                                        <option value="Louisiana">Louisiana</option>
+                                                        <option value="Maine">Maine</option>
+                                                        <option value="Maryland">Maryland</option>
+                                                        <option value="Massachusetts">Massachusetts</option>
+                                                        <option value="Michigan">Michigan</option>
+                                                        <option value="Minnesota">Minnesota</option>
+                                                        <option value="Mississippi">Mississippi</option>
+                                                        <option value="Missouri">Missouri</option>
+                                                        <option value="Montana">Montana</option>
+                                                        <option value="Nebraska">Nebraska</option>
+                                                        <option value="Nevada">Nevada</option>
+                                                        <option value="New Hampshire">New Hampshire</option>
+                                                        <option value="New Jersey">New Jersey</option>
+                                                        <option value="New Mexico">New Mexico</option>
+                                                        <option value="New York">New York</option>
+                                                        <option value="North Carolina">North Carolina</option>
+                                                        <option value="North Dakota">North Dakota</option>
+                                                        <option value="Ohio">Ohio</option>
+                                                        <option value="Oklahoma">Oklahoma</option>
+                                                        <option value="Oregon">Oregon</option>
+                                                        <option value="Pennsylvania">Pennsylvania</option>
+                                                        <option value="Rhode Island">Rhode Island</option>
+                                                        <option value="South Carolina">South Carolina</option>
+                                                        <option value="South Dakota">South Dakota</option>
+                                                        <option value="Tennessee">Tennessee</option>
+                                                        <option value="Texas">Texas</option>
+                                                        <option value="Utah">Utah</option>
+                                                        <option value="Vermont">Vermont</option>
+                                                        <option value="Virginia">Virginia</option>
+                                                        <option value="Washington">Washington</option>
+                                                        <option value="West Virginia">West Virginia</option>
+                                                        <option value="Wisconsin">Wisconsin</option>
+                                                        <option value="Wyoming">Wyoming</option>
+                                                    </select>
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                    <label>Type</label>
+                                                    <span>
+                                                        <select class="form-control ge-name-type" name="nameType"   style="" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                            <option th:value="${exceuter.getEntityAlternateNameType()}" th:text="${exceuter.getEntityAlternateNameType()}" selected>Select</option>
+                                                            <option value="">Select</option>
+                                                            <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
+                                                            <option value="Trading As(TA)">Trading As(TA)</option>
+                                                            <option value="Also Known As(AKA)">Also Known As(AKA)</option>
+                                                            <option value="Formerly">Formerly</option>
+                                                        </select>
+                                                    </span>
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-sm-6" style="">
+                                                    <label for="nameoftype">Name</label>
+                                                    <input type="text" class="form-control partner-alt-name"  name="nameoftype" th:value="${exceuter.getEntityAlternateName()}"   th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"><!--needs th:attribute-->
+                                                </div>
+                                            </th:block>
+                                        </div>  <!--end of partner row from server  -->
                                     </th:block>
-                                    <th:block th:if="${exceuter.isPersonEntity() == true}">
-                                        <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
-                                            <label ><span class="weight600">&#42;</span>First name</label>
-                                            <input type="text"  name="firstName" class="form-control ge-first-name" th:value="${exceuter.firstName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}" >
+                                </fieldset>
+                                <div class="col-xs-12 form-group form-group-md">
+                                    <div class="row addpartnership" style="display: none;">
+                                        <div class="form-group form-group-md col-xs-12 visuallyremoved resetpartner">
+                                            <button type="button" class="btn btn-sm close resetpartnerbtn" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
                                         </div>
-                                        <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
-                                            <label >Middle name</label>
-                                            <input type="text"  name="middleName" class="form-control ge-middle-name" th:value="${exceuter.middleName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                        <div class="col-xs-12 form-group form-group-md">
+                                            <label>Select entity type</label>
+                                            <span>
+                                                <select id="domestic-entity-dropdown-partner" class="form-control" name="nameType">
+                                                    <option id="opt-none" value="none"></option>
+                                                    <option id="opt-domestic-ind" value="Individual">Individual</option>
+                                                    <option id="opt-domestic-soleP" value="Sole Proprietorship">Sole Proprietorship</option>
+                                                    <option id="opt-domestic-llc" value="Limited Liability Company">Limited Liability Company</option>
+                                                    <option id="opt-domestic-part" value="Partnership">Partnership</option>
+                                                    <option id="opt-domestic-jvc" value="Joint Venture">Joint Venture</option>
+                                                    <option id="opt-domestic-trt" value="Trust">Trust</option>
+                                                    <option id="opt-domestic-est" value="Estate">Estate</option>
+                                                </select>
+                                            </span>
                                         </div>
-                                        <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
-                                            <label ><span class="weight600">&#42;</span>Last name</label>
-                                            <input  type="text"  name="lastName" class="form-control ge-last-name" th:value="${exceuter.lastName}"   th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                        <div class="col-xs-12">
+                                            <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity-new" style="display: none;">
+                                                <div class="row">
+                                                    <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
+                                                        <label><span class="weight600">&#42;</span>First name</label>
+                                                        <input type="text"   class="form-control ge-first-name"  required value="">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
+                                                        <label >Middle name</label>
+                                                        <input type="text" class="form-control ge-middle-name" value="">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
+                                                        <label ><span class="weight600">&#42;</span>Last name</label>
+                                                        <input  type="text"  class="form-control ge-last-name" required value="">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
+                                                        <label for="partner-suffix">Suffix</label>
+                                                        <input type="text" class="form-control" id="partner-suffix" value="">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
+                                                        <label>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                                        <select class="form-control ge-citizenship">
+                                                            <option value="">Select</option>
+                                                            <option value="United States of America">United States of America</option>
+                                                            <option value="Afghanistan">Afghanistan</option>
+                                                            <option value="Albania">Albania</option>
+                                                            <option value="Algeria">Algeria</option>
+                                                            <option value="American Samoa">American Samoa</option>
+                                                            <option value="Andorra">Andorra</option>
+                                                            <option value="Angola">Angola</option>
+                                                            <option value="Anguilla">Anguilla</option>
+                                                            <option value="Antarctica">Antarctica</option>
+                                                            <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+                                                            <option value="Argentina">Argentina</option>
+                                                            <option value="Armenia">Armenia</option>
+                                                            <option value="Aruba">Aruba</option>
+                                                            <option value="Australia">Australia</option>
+                                                            <option value="Austria">Austria</option>
+                                                            <option value="Azerbaijan">Azerbaijan</option>
+                                                            <option value="Bahamas">Bahamas</option>
+                                                            <option value="Bahrain">Bahrain</option>
+                                                            <option value="Bangladesh">Bangladesh</option>
+                                                            <option value="Barbados">Barbados</option>
+                                                            <option value="Belarus">Belarus</option>
+                                                            <option value="Belgium">Belgium</option>
+                                                            <option value="Belize">Belize</option>
+                                                            <option value="Benin">Benin</option>
+                                                            <option value="Bermuda">Bermuda</option>
+                                                            <option value="Bhutan">Bhutan</option>
+                                                            <option value="Bolivia">Bolivia</option>
+                                                            <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+                                                            <option value="Botswana">Botswana</option>
+                                                            <option value="Bouvet Island">Bouvet Island</option>
+                                                            <option value="Brazil">Brazil</option>
+                                                            <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+                                                            <option value="Brunei Darussalam">Brunei Darussalam</option>
+                                                            <option value="Bulgaria">Bulgaria</option>
+                                                            <option value="Burkina Faso">Burkina Faso</option>
+                                                            <option value="Burundi">Burundi</option>
+                                                            <option value="Canada">Canada</option>
+                                                            <option value="Cambodia">Cambodia</option>
+                                                            <option value="Cameroon">Cameroon</option>
+                                                            <option value="Cape Verde">Cape Verde</option>
+                                                            <option value="Cayman Islands">Cayman Islands</option>
+                                                            <option value="Central African Republic">Central African Republic</option>
+                                                            <option value="Chad">Chad</option>
+                                                            <option value="Chile">Chile</option>
+                                                            <option value="China">China</option>
+                                                            <option value="Christmas Island">Christmas Island</option>
+                                                            <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+                                                            <option value="Colombia">Colombia</option>
+                                                            <option value="Comoros">Comoros</option>
+                                                            <option value="Congo">Congo</option>
+                                                            <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
+                                                            <option value="Cook Islands">Cook Islands</option>
+                                                            <option value="Costa Rica">Costa Rica</option>
+                                                            <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
+                                                            <option value="Croatia">Croatia</option>
+                                                            <option value="Cuba">Cuba</option>
+                                                            <option value="Cyprus">Cyprus</option>
+                                                            <option value="Czech Republic">Czech Republic</option>
+                                                            <option value="Denmark">Denmark</option>
+                                                            <option value="Djibouti">Djibouti</option>
+                                                            <option value="Dominica">Dominica</option>
+                                                            <option value="Dominican Republic">Dominican Republic</option>
+                                                            <option value="East Timor">East Timor</option>
+                                                            <option value="Ecuador">Ecuador</option>
+                                                            <option value="Egypt">Egypt</option>
+                                                            <option value="El Salvador">El Salvador</option>
+                                                            <option value="Equatorial Guinea">Equatorial Guinea</option>
+                                                            <option value="Eritrea">Eritrea</option>
+                                                            <option value="Estonia">Estonia</option>
+                                                            <option value="Ethiopia">Ethiopia</option>
+                                                            <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+                                                            <option value="Faroe Islands">Faroe Islands</option>
+                                                            <option value="Fiji">Fiji</option>
+                                                            <option value="Finland">Finland</option>
+                                                            <option value="France">France</option>
+                                                            <option value="French Guiana">French Guiana</option>
+                                                            <option value="French Polynesia">French Polynesia</option>
+                                                            <option value="French Southern Territories">French Southern Territories</option>
+                                                            <option value="Gabon">Gabon</option>
+                                                            <option value="Gambia">Gambia</option>
+                                                            <option value="Georgia">Georgia</option>
+                                                            <option value="Germany">Germany</option>
+                                                            <option value="Ghana">Ghana</option>
+                                                            <option value="Gibraltar">Gibraltar</option>
+                                                            <option value="Greece">Greece</option>
+                                                            <option value="Greenland">Greenland</option>
+                                                            <option value="Grenada">Grenada</option>
+                                                            <option value="Guadeloupe">Guadeloupe</option>
+                                                            <option value="Guam">Guam</option>
+                                                            <option value="Guatemala">Guatemala</option>
+                                                            <option value="Guinea">Guinea</option>
+                                                            <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
+                                                            <option value="Guyana">Guyana</option>
+                                                            <option value="Haiti">Haiti</option>
+                                                            <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+                                                            <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+                                                            <option value="Honduras">Honduras</option>
+                                                            <option value="Hong Kong">Hong Kong</option>
+                                                            <option value="Hungary">Hungary</option>
+                                                            <option value="Iceland">Iceland</option>
+                                                            <option value="India">India</option>
+                                                            <option value="Indonesia">Indonesia</option>
+                                                            <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+                                                            <option value="Iraq">Iraq</option>
+                                                            <option value="Ireland">Ireland</option>
+                                                            <option value="Israel">Israel</option>
+                                                            <option value="Italy">Italy</option>
+                                                            <option value="Jamaica">Jamaica</option>
+                                                            <option value="Japan">Japan</option>
+                                                            <option value="Jordan">Jordan</option>
+                                                            <option value="Kazakstan">Kazakstan</option>
+                                                            <option value="Kenya">Kenya</option>
+                                                            <option value="Kiribati">Kiribati</option>
+                                                            <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
+                                                            <option value="Korea, Republic of">Korea, Republic of</option>
+                                                            <option value="Kuwait">Kuwait</option>
+                                                            <option value="Kyrgyzstan">Kyrgyzstan</option>
+                                                            <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
+                                                            <option value="Latvia">Latvia</option>
+                                                            <option value="Lebanon">Lebanon</option>
+                                                            <option value="Lesotho">Lesotho</option>
+                                                            <option value="Liberia">Liberia</option>
+                                                            <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
+                                                            <option value="Liechtenstein">Liechtenstein</option>
+                                                            <option value="Lithuania">Lithuania</option>
+                                                            <option value="Luxembourg">Luxembourg</option>
+                                                            <option value="Macau">Macau</option>
+                                                            <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
+                                                            <option value="Madagascar">Madagascar</option>
+                                                            <option value="Malawi">Malawi</option>
+                                                            <option value="Malaysia">Malaysia</option>
+                                                            <option value="Maldives">Maldives</option>
+                                                            <option value="Mali">Mali</option>
+                                                            <option value="Malta">Malta</option>
+                                                            <option value="Marshall Islands">Marshall Islands</option>
+                                                            <option value="Martinique">Martinique</option>
+                                                            <option value="Mauritania">Mauritania</option>
+                                                            <option value="Mauritius">Mauritius</option>
+                                                            <option value="Mayotte">Mayotte</option>
+                                                            <option value="Mexico">Mexico</option>
+                                                            <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+                                                            <option value="Moldova, Republic of">Moldova, Republic of</option>
+                                                            <option value="Monaco">Monaco</option>
+                                                            <option value="Mongolia">Mongolia</option>
+                                                            <option value="Montserrat">Montserrat</option>
+                                                            <option value="Morocco">Morocco</option>
+                                                            <option value="Mozambique">Mozambique</option>
+                                                            <option value="Myanmar">Myanmar</option>
+                                                            <option value="Namibia">Namibia</option>
+                                                            <option value="Nauru">Nauru</option>
+                                                            <option value="Nepal">Nepal</option>
+                                                            <option value="Netherlands">Netherlands</option>
+                                                            <option value="Netherlands Antilles">Netherlands Antilles</option>
+                                                            <option value="New Caledonia">New Caledonia</option>
+                                                            <option value="New Zealand">New Zealand</option>
+                                                            <option value="Nicaragua">Nicaragua</option>
+                                                            <option value="Niger">Niger</option>
+                                                            <option value="Nigeria">Nigeria</option>
+                                                            <option value="Niue">Niue</option>
+                                                            <option value="Norfolk Island">Norfolk Island</option>
+                                                            <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+                                                            <option value="Norway">Norway</option>
+                                                            <option value="Oman">Oman</option>
+                                                            <option value="Pakistan">Pakistan</option>
+                                                            <option value="Palau">Palau</option>
+                                                            <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+                                                            <option value="Panama">Panama</option>
+                                                            <option value="Papua New Guinea">Papua New Guinea</option>
+                                                            <option value="Paraguay">Paraguay</option>
+                                                            <option value="Peru">Peru</option>
+                                                            <option value="Philippines">Philippines</option>
+                                                            <option value="Pitcairn">Pitcairn</option>
+                                                            <option value="Poland">Poland</option>
+                                                            <option value="Portugal">Portugal</option>
+                                                            <option value="Puerto Rico">Puerto Rico</option>
+                                                            <option value="Qatar">Qatar</option>
+                                                            <option value="Reunion">Reunion</option>
+                                                            <option value="Romania">Romania</option>
+                                                            <option value="Russian Federation">Russian Federation</option>
+                                                            <option value="Rwanda">Rwanda</option>
+                                                            <option value="Saint Helena">Saint Helena</option>
+                                                            <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+                                                            <option value="Saint Lucia">Saint Lucia</option>
+                                                            <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+                                                            <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
+                                                            <option value="Samoa">Samoa</option>
+                                                            <option value="San Marino">San Marino</option>
+                                                            <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+                                                            <option value="Saudi Arabia">Saudi Arabia</option>
+                                                            <option value="Senegal">Senegal</option>
+                                                            <option value="Seychelles">Seychelles</option>
+                                                            <option value="Sierra Leone">Sierra Leone</option>
+                                                            <option value="Singapore">Singapore</option>
+                                                            <option value="Slovakia">Slovakia</option>
+                                                            <option value="Slovenia">Slovenia</option>
+                                                            <option value="Solomon Islands">Solomon Islands</option>
+                                                            <option value="Somalia">Somalia</option>
+                                                            <option value="South Africa">South Africa</option>
+                                                            <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
+                                                            <option value="Spain">Spain</option>
+                                                            <option value="Sri Lanka">Sri Lanka</option>
+                                                            <option value="Sudan">Sudan</option>
+                                                            <option value="Suriname">Suriname</option>
+                                                            <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+                                                            <option value="Swaziland">Swaziland</option>
+                                                            <option value="Sweden">Sweden</option>
+                                                            <option value="Switzerland">Switzerland</option>
+                                                            <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+                                                            <option value="Taiwan">Taiwan</option>
+                                                            <option value="Tajikistan">Tajikistan</option>
+                                                            <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+                                                            <option value="Thailand">Thailand</option>
+                                                            <option value="Togo">Togo</option>
+                                                            <option value="Tokelau">Tokelau</option>
+                                                            <option value="Tonga">Tonga</option>
+                                                            <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+                                                            <option value="Tunisia">Tunisia</option>
+                                                            <option value="Turkey">Turkey</option>
+                                                            <option value="Turkmenistan">Turkmenistan</option>
+                                                            <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+                                                            <option value="Tuvalu">Tuvalu</option>
+                                                            <option value="Uganda">Uganda</option>
+                                                            <option value="Ukraine">Ukraine</option>
+                                                            <option value="United Arab Emirates">United Arab Emirates</option>
+                                                            <option value="United Kingdom">United Kingdom</option>
+                                                            <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+                                                            <option value="Uruguay">Uruguay</option>
+                                                            <option value="Uzbekistan">Uzbekistan</option>
+                                                            <option value="Vanuatu">Vanuatu</option>
+                                                            <option value="Venezuela">Venezuela</option>
+                                                            <option value="Viet Nam">Viet Nam</option>
+                                                            <option value="Virgin Islands, British">Virgin Islands, British</option>
+                                                            <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+                                                            <option value="Wallis and Futuna">Wallis and Futuna</option>
+                                                            <option value="Western Sahara">Western Sahara</option>
+                                                            <option value="Yemen">Yemen</option>
+                                                            <option value="Yugoslavia">Yugoslavia</option>
+                                                            <option value="Zambia">Zambia</option>
+                                                            <option value="Zimbabwe">Zimbabwe</option>
+                                                            <option value="Unknown">Unknown</option>
+                                                        </select>
+                                                    </div>
+                                                </div>
+                                            </fieldset>
+                                            <fieldset aria-labelledby="proprietorinfo" id="none-individual-partner-entity-new" style="display: none;">
+                                                <div class="row">
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                        <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
+                                                        <input type="text" class="form-control rounded-borders ge-name" required  value="">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                        <label>State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
+                                                        <select class="form-control ge-state">
+                                                            <option value="">Select</option>
+                                                            <option value="Alabama">Alabama</option>
+                                                            <option value="Alaska">Alaska</option>
+                                                            <option value="Arizona">Arizona</option>
+                                                            <option value="Arkansas">Arkansas</option>
+                                                            <option value="California">California</option>
+                                                            <option value="Colorado">Colorado</option>
+                                                            <option value="Connecticut">Connecticut</option>
+                                                            <option value="Delaware">Delaware</option>
+                                                            <option value="District of Columbia">District of Columbia</option>
+                                                            <option value="Florida">Florida</option>
+                                                            <option value="Georgia">Georgia</option>
+                                                            <option value="Hawaii">Hawaii</option>
+                                                            <option value="Idaho">Idaho</option>
+                                                            <option value="Illinois">Illinois</option>
+                                                            <option value="Indiana">Indiana</option>
+                                                            <option value="Iowa">Iowa</option>
+                                                            <option value="Kansas">Kansas</option>
+                                                            <option value="Kentucky">Kentucky</option>
+                                                            <option value="Louisiana">Louisiana</option>
+                                                            <option value="Maine">Maine</option>
+                                                            <option value="Maryland">Maryland</option>
+                                                            <option value="Massachusetts">Massachusetts</option>
+                                                            <option value="Michigan">Michigan</option>
+                                                            <option value="Minnesota">Minnesota</option>
+                                                            <option value="Mississippi">Mississippi</option>
+                                                            <option value="Missouri">Missouri</option>
+                                                            <option value="Montana">Montana</option>
+                                                            <option value="Nebraska">Nebraska</option>
+                                                            <option value="Nevada">Nevada</option>
+                                                            <option value="New Hampshire">New Hampshire</option>
+                                                            <option value="New Jersey">New Jersey</option>
+                                                            <option value="New Mexico">New Mexico</option>
+                                                            <option value="New York">New York</option>
+                                                            <option value="North Carolina">North Carolina</option>
+                                                            <option value="North Dakota">North Dakota</option>
+                                                            <option value="Ohio">Ohio</option>
+                                                            <option value="Oklahoma">Oklahoma</option>
+                                                            <option value="Oregon">Oregon</option>
+                                                            <option value="Pennsylvania">Pennsylvania</option>
+                                                            <option value="Rhode Island">Rhode Island</option>
+                                                            <option value="South Carolina">South Carolina</option>
+                                                            <option value="South Dakota">South Dakota</option>
+                                                            <option value="Tennessee">Tennessee</option>
+                                                            <option value="Texas">Texas</option>
+                                                            <option value="Utah">Utah</option>
+                                                            <option value="Vermont">Vermont</option>
+                                                            <option value="Virginia">Virginia</option>
+                                                            <option value="Washington">Washington</option>
+                                                            <option value="West Virginia">West Virginia</option>
+                                                            <option value="Wisconsin">Wisconsin</option>
+                                                            <option value="Wyoming">Wyoming</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                        <label>Type</label>
+                                                        <span>
+                                                            <select class="form-control ge-name-type" >
+                                                                <option value="">Select</option>
+                                                                <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
+                                                                <option value="Trading As(TA)">Trading As(TA)</option>
+                                                                <option value="Also Known As(AKA)">Also Known As(AKA)</option>
+                                                                <option value="Formerly">Formerly</option>
+                                                            </select>
+                                                        </span>
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-6" style="">
+                                                        <label for="nameoftype">Name</label>
+                                                        <input type="text" class="form-control partner-alt-name"  name="nameoftype" ><!--needs th:attribute-->
+                                                    </div>
+                                                </div>
+                                            </fieldset>
+                                        </div> <!-- end of arrary dto object -->
+                                    </div>
+                                </div>
+                                <!--END hidden content-->
+                                <div class="appendpartner col-xs-12"></div>
+                                <div class="row" id="hideshow_addpartner">
+
+                                    <div class="col-xs-12 form-group form-group-md" aria-label="add a partner">
+                                        <div class="inlinebuttons btn-group btn-group-justified">
+                                            <div class="btn-group col-xs-6">
+                                                <button type="button" class="btn btn-sm btn-success addinitial" id="addpartner">Add Partner</button>
+                                            </div>
                                         </div>
-                                        <div class="form-group form-group-md col-xs-6">
-                                            <label>Suffix</label>
-                                            <input  class="form-control ge-suffix"  name="suffix" />
-                                        </div>
-                                        <div class="form-group form-group-md col-xs-6">
-                                            <label><span class="weight600">&#42;</span>Country of citizenship</label>
-                                            <select class="form-control ge-citizenship" name="owner-citizenship" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
-                                                <option th:value="${exceuter.entityCitizenship}"  th:text="${exceuter.entityCitizenship}" selected  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"></option>
+                                    </div><!--// add button-->
+                                </div><!--// hide / show add partner-->
+                                <!--END Sole Proprietor Information Form-->
+                                <!--START Owner Address Information Form-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="addressinfo">Owner Address Information</h2>
+                                </div>
+                                <fieldset aria-labelledby="addressinfo">
+                                    <div class="row">
+                                        <div class="form-group form-group-md col-md-12 col-lg-7">
+                                            <label for="OwnerAddressCountry"><span class="weight600">&#42;</span>Country / U.S. territory</label>
+                                            <select class="form-control" id="OwnerAddressCountry" name="territory" th:field="${owner.country}" >
                                                 <option value="">Select</option>
                                                 <option value="United States of America">United States of America</option>
                                                 <option value="Afghanistan">Afghanistan</option>
@@ -457,16 +1179,25 @@
                                                 <option value="Unknown">Unknown</option>
                                             </select>
                                         </div>
-                                    </th:block>
-                                    <th:block th:if="${exceuter.isPersonEntity() == false}">
-                                        <div class="form-group form-group-md col-xs-6">
-                                            <label ><span class="weight600">&#42;</span>Owner name</label>
-                                            <input  type="text"   class="form-control rounded-borders ge-name"  style="" th:value="${exceuter.entityName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                        <div class="form-group form-group-md col-md-12 col-lg-9">
+                                            <label for="ownerAddress1"><span class="weight600">&#42;</span>Address line 1</label>
+                                            <input type="text" class="form-control" id="ownerAddress1" th:value="${owner.address1}" >
                                         </div>
-                                        <div class="form-group form-group-md col-xs-6">
-                                            <label><span class="weight600">&#42;</span>State where legally organized</label>
-                                            <select class="form-control ge-state" name="State" th:attr="entity-index=${iter.index}" >
-                                                <option th:value="${exceuter.organizationState}" th:text="${exceuter.organizationState}"  th:attr="entity-id=${exceuter.id}"selected></option>
+                                        <div class="form-group form-group-md col-md-12 col-lg-9">
+                                            <label for="addressline2">Address line 2</label>
+                                            <input type="text" class="form-control" id="addressline2" >
+                                        </div>
+                                        <div class="form-group form-group-md col-md-12 col-lg-9">
+                                            <label for="addressline3">Address line 3</label>
+                                            <input type="text" class="form-control" id="addressline3" >
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                            <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
+                                            <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}">
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                            <label for="ownerState"><span class="weight600">&#42;</span>State/Province/Territory</label>
+                                            <select class="form-control" id="ownerState" th:field="${owner.state}" required>
                                                 <option value="">Select</option>
                                                 <option value="Alabama">Alabama</option>
                                                 <option value="Alaska">Alaska</option>
@@ -521,798 +1252,69 @@
                                                 <option value="Wyoming">Wyoming</option>
                                             </select>
                                         </div>
-                                        <div class="form-group form-group-md col-xs-6">
-                                            <label>Type</label>
-                                            <span>
-                                                <select class="form-control ge-name-type" name="nameType"   style="" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
-                                                    <option th:value="${exceuter.getEntityAlternateNameType()}" th:text="${exceuter.getEntityAlternateNameType()}" selected>Select</option>
-                                                    <option value="">Select</option>
-                                                    <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
-                                                    <option value="Trading As(TA)">Trading As(TA)</option>
-                                                    <option value="Also Known As(AKA)">Also Known As(AKA)</option>
-                                                    <option value="Formerly">Formerly</option>
-                                                </select>
-                                            </span>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-5">
+                                            <label for="ownerZipcode"><span class="weight600">&#42;</span>Zip code/Postal code</label>
+                                            <input type="text" class="form-control" id="ownerZipcode" placeholder=""  th:value="${owner.zipcode}">
                                         </div>
-                                        <div class="form-group form-group-md col-xs-6" style="">
-                                            <label for="nameoftype">Name</label>
-                                            <input type="text" class="form-control partner-alt-name"  name="nameoftype" th:value="${exceuter.getEntityAlternateName()}"   th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"><!--needs th:attribute-->
-                                        </div>
-                                    </th:block>
-                                </div>  <!--end of partner row from server  -->
-                            </th:block>
-                        </fieldset>
-                        <div class="col-xs-12 form-group form-group-md">
-                            <div class="row addpartnership" style="display: none;">
-                                <div class="form-group form-group-md col-xs-12 visuallyremoved resetpartner">
-                                    <button type="button" class="btn btn-sm close resetpartnerbtn" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
+                                    </div>
+                                </fieldset>
+                                <!--END Owner Address Information Form-->
+                                <!--START Additional Information Form-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="additionalinfo">Additional Information</h2>
                                 </div>
-                                <div class="col-xs-12 form-group form-group-md">
-                                    <label>Select entity type</label>
-                                    <span>
-                                        <select id="domestic-entity-dropdown-partner" class="form-control" name="nameType">
-                                            <option id="opt-none" value="none"></option>
-                                            <option id="opt-domestic-ind" value="Individual">Individual</option>
-                                            <option id="opt-domestic-soleP" value="Sole Proprietorship">Sole Proprietorship</option>
-                                            <option id="opt-domestic-llc" value="Limited Liability Company">Limited Liability Company</option>
-                                            <option id="opt-domestic-part" value="Partnership">Partnership</option>
-                                            <option id="opt-domestic-jvc" value="Joint Venture">Joint Venture</option>
-                                            <option id="opt-domestic-trt" value="Trust">Trust</option>
-                                            <option id="opt-domestic-est" value="Estate">Estate</option>
-                                        </select>
-                                    </span>
-                                </div>
-                                <div class="col-xs-12">
-                                    <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity-new" style="display: none;">
-                                        <div class="row">
-                                            <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
-                                                <label><span class="weight600">&#42;</span>First name</label>
-                                                <input type="text"   class="form-control ge-first-name"  required value="">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
-                                                <label >Middle name</label>
-                                                <input type="text" class="form-control ge-middle-name" value="">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
-                                                <label ><span class="weight600">&#42;</span>Last name</label>
-                                                <input  type="text"  class="form-control ge-last-name" required value="">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label for="partner-suffix">Suffix</label>
-                                                <input class="form-control" id="partner-suffix" value="">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label><span class="weight600">&#42;</span>Country of citizenship</label>
-                                                <select class="form-control ge-citizenship"  required="">
-                                                    <option value="">Select</option>
-                                                    <option value="United States of America">United States of America</option>
-                                                    <option value="Afghanistan">Afghanistan</option>
-                                                    <option value="Albania">Albania</option>
-                                                    <option value="Algeria">Algeria</option>
-                                                    <option value="American Samoa">American Samoa</option>
-                                                    <option value="Andorra">Andorra</option>
-                                                    <option value="Angola">Angola</option>
-                                                    <option value="Anguilla">Anguilla</option>
-                                                    <option value="Antarctica">Antarctica</option>
-                                                    <option value="Antigua and Barbuda">Antigua and Barbuda</option>
-                                                    <option value="Argentina">Argentina</option>
-                                                    <option value="Armenia">Armenia</option>
-                                                    <option value="Aruba">Aruba</option>
-                                                    <option value="Australia">Australia</option>
-                                                    <option value="Austria">Austria</option>
-                                                    <option value="Azerbaijan">Azerbaijan</option>
-                                                    <option value="Bahamas">Bahamas</option>
-                                                    <option value="Bahrain">Bahrain</option>
-                                                    <option value="Bangladesh">Bangladesh</option>
-                                                    <option value="Barbados">Barbados</option>
-                                                    <option value="Belarus">Belarus</option>
-                                                    <option value="Belgium">Belgium</option>
-                                                    <option value="Belize">Belize</option>
-                                                    <option value="Benin">Benin</option>
-                                                    <option value="Bermuda">Bermuda</option>
-                                                    <option value="Bhutan">Bhutan</option>
-                                                    <option value="Bolivia">Bolivia</option>
-                                                    <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
-                                                    <option value="Botswana">Botswana</option>
-                                                    <option value="Bouvet Island">Bouvet Island</option>
-                                                    <option value="Brazil">Brazil</option>
-                                                    <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
-                                                    <option value="Brunei Darussalam">Brunei Darussalam</option>
-                                                    <option value="Bulgaria">Bulgaria</option>
-                                                    <option value="Burkina Faso">Burkina Faso</option>
-                                                    <option value="Burundi">Burundi</option>
-                                                    <option value="Canada">Canada</option>
-                                                    <option value="Cambodia">Cambodia</option>
-                                                    <option value="Cameroon">Cameroon</option>
-                                                    <option value="Cape Verde">Cape Verde</option>
-                                                    <option value="Cayman Islands">Cayman Islands</option>
-                                                    <option value="Central African Republic">Central African Republic</option>
-                                                    <option value="Chad">Chad</option>
-                                                    <option value="Chile">Chile</option>
-                                                    <option value="China">China</option>
-                                                    <option value="Christmas Island">Christmas Island</option>
-                                                    <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
-                                                    <option value="Colombia">Colombia</option>
-                                                    <option value="Comoros">Comoros</option>
-                                                    <option value="Congo">Congo</option>
-                                                    <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
-                                                    <option value="Cook Islands">Cook Islands</option>
-                                                    <option value="Costa Rica">Costa Rica</option>
-                                                    <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
-                                                    <option value="Croatia">Croatia</option>
-                                                    <option value="Cuba">Cuba</option>
-                                                    <option value="Cyprus">Cyprus</option>
-                                                    <option value="Czech Republic">Czech Republic</option>
-                                                    <option value="Denmark">Denmark</option>
-                                                    <option value="Djibouti">Djibouti</option>
-                                                    <option value="Dominica">Dominica</option>
-                                                    <option value="Dominican Republic">Dominican Republic</option>
-                                                    <option value="East Timor">East Timor</option>
-                                                    <option value="Ecuador">Ecuador</option>
-                                                    <option value="Egypt">Egypt</option>
-                                                    <option value="El Salvador">El Salvador</option>
-                                                    <option value="Equatorial Guinea">Equatorial Guinea</option>
-                                                    <option value="Eritrea">Eritrea</option>
-                                                    <option value="Estonia">Estonia</option>
-                                                    <option value="Ethiopia">Ethiopia</option>
-                                                    <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
-                                                    <option value="Faroe Islands">Faroe Islands</option>
-                                                    <option value="Fiji">Fiji</option>
-                                                    <option value="Finland">Finland</option>
-                                                    <option value="France">France</option>
-                                                    <option value="French Guiana">French Guiana</option>
-                                                    <option value="French Polynesia">French Polynesia</option>
-                                                    <option value="French Southern Territories">French Southern Territories</option>
-                                                    <option value="Gabon">Gabon</option>
-                                                    <option value="Gambia">Gambia</option>
-                                                    <option value="Georgia">Georgia</option>
-                                                    <option value="Germany">Germany</option>
-                                                    <option value="Ghana">Ghana</option>
-                                                    <option value="Gibraltar">Gibraltar</option>
-                                                    <option value="Greece">Greece</option>
-                                                    <option value="Greenland">Greenland</option>
-                                                    <option value="Grenada">Grenada</option>
-                                                    <option value="Guadeloupe">Guadeloupe</option>
-                                                    <option value="Guam">Guam</option>
-                                                    <option value="Guatemala">Guatemala</option>
-                                                    <option value="Guinea">Guinea</option>
-                                                    <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
-                                                    <option value="Guyana">Guyana</option>
-                                                    <option value="Haiti">Haiti</option>
-                                                    <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
-                                                    <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
-                                                    <option value="Honduras">Honduras</option>
-                                                    <option value="Hong Kong">Hong Kong</option>
-                                                    <option value="Hungary">Hungary</option>
-                                                    <option value="Iceland">Iceland</option>
-                                                    <option value="India">India</option>
-                                                    <option value="Indonesia">Indonesia</option>
-                                                    <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
-                                                    <option value="Iraq">Iraq</option>
-                                                    <option value="Ireland">Ireland</option>
-                                                    <option value="Israel">Israel</option>
-                                                    <option value="Italy">Italy</option>
-                                                    <option value="Jamaica">Jamaica</option>
-                                                    <option value="Japan">Japan</option>
-                                                    <option value="Jordan">Jordan</option>
-                                                    <option value="Kazakstan">Kazakstan</option>
-                                                    <option value="Kenya">Kenya</option>
-                                                    <option value="Kiribati">Kiribati</option>
-                                                    <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
-                                                    <option value="Korea, Republic of">Korea, Republic of</option>
-                                                    <option value="Kuwait">Kuwait</option>
-                                                    <option value="Kyrgyzstan">Kyrgyzstan</option>
-                                                    <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
-                                                    <option value="Latvia">Latvia</option>
-                                                    <option value="Lebanon">Lebanon</option>
-                                                    <option value="Lesotho">Lesotho</option>
-                                                    <option value="Liberia">Liberia</option>
-                                                    <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
-                                                    <option value="Liechtenstein">Liechtenstein</option>
-                                                    <option value="Lithuania">Lithuania</option>
-                                                    <option value="Luxembourg">Luxembourg</option>
-                                                    <option value="Macau">Macau</option>
-                                                    <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
-                                                    <option value="Madagascar">Madagascar</option>
-                                                    <option value="Malawi">Malawi</option>
-                                                    <option value="Malaysia">Malaysia</option>
-                                                    <option value="Maldives">Maldives</option>
-                                                    <option value="Mali">Mali</option>
-                                                    <option value="Malta">Malta</option>
-                                                    <option value="Marshall Islands">Marshall Islands</option>
-                                                    <option value="Martinique">Martinique</option>
-                                                    <option value="Mauritania">Mauritania</option>
-                                                    <option value="Mauritius">Mauritius</option>
-                                                    <option value="Mayotte">Mayotte</option>
-                                                    <option value="Mexico">Mexico</option>
-                                                    <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
-                                                    <option value="Moldova, Republic of">Moldova, Republic of</option>
-                                                    <option value="Monaco">Monaco</option>
-                                                    <option value="Mongolia">Mongolia</option>
-                                                    <option value="Montserrat">Montserrat</option>
-                                                    <option value="Morocco">Morocco</option>
-                                                    <option value="Mozambique">Mozambique</option>
-                                                    <option value="Myanmar">Myanmar</option>
-                                                    <option value="Namibia">Namibia</option>
-                                                    <option value="Nauru">Nauru</option>
-                                                    <option value="Nepal">Nepal</option>
-                                                    <option value="Netherlands">Netherlands</option>
-                                                    <option value="Netherlands Antilles">Netherlands Antilles</option>
-                                                    <option value="New Caledonia">New Caledonia</option>
-                                                    <option value="New Zealand">New Zealand</option>
-                                                    <option value="Nicaragua">Nicaragua</option>
-                                                    <option value="Niger">Niger</option>
-                                                    <option value="Nigeria">Nigeria</option>
-                                                    <option value="Niue">Niue</option>
-                                                    <option value="Norfolk Island">Norfolk Island</option>
-                                                    <option value="Northern Mariana Islands">Northern Mariana Islands</option>
-                                                    <option value="Norway">Norway</option>
-                                                    <option value="Oman">Oman</option>
-                                                    <option value="Pakistan">Pakistan</option>
-                                                    <option value="Palau">Palau</option>
-                                                    <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
-                                                    <option value="Panama">Panama</option>
-                                                    <option value="Papua New Guinea">Papua New Guinea</option>
-                                                    <option value="Paraguay">Paraguay</option>
-                                                    <option value="Peru">Peru</option>
-                                                    <option value="Philippines">Philippines</option>
-                                                    <option value="Pitcairn">Pitcairn</option>
-                                                    <option value="Poland">Poland</option>
-                                                    <option value="Portugal">Portugal</option>
-                                                    <option value="Puerto Rico">Puerto Rico</option>
-                                                    <option value="Qatar">Qatar</option>
-                                                    <option value="Reunion">Reunion</option>
-                                                    <option value="Romania">Romania</option>
-                                                    <option value="Russian Federation">Russian Federation</option>
-                                                    <option value="Rwanda">Rwanda</option>
-                                                    <option value="Saint Helena">Saint Helena</option>
-                                                    <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
-                                                    <option value="Saint Lucia">Saint Lucia</option>
-                                                    <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
-                                                    <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
-                                                    <option value="Samoa">Samoa</option>
-                                                    <option value="San Marino">San Marino</option>
-                                                    <option value="Sao Tome and Principe">Sao Tome and Principe</option>
-                                                    <option value="Saudi Arabia">Saudi Arabia</option>
-                                                    <option value="Senegal">Senegal</option>
-                                                    <option value="Seychelles">Seychelles</option>
-                                                    <option value="Sierra Leone">Sierra Leone</option>
-                                                    <option value="Singapore">Singapore</option>
-                                                    <option value="Slovakia">Slovakia</option>
-                                                    <option value="Slovenia">Slovenia</option>
-                                                    <option value="Solomon Islands">Solomon Islands</option>
-                                                    <option value="Somalia">Somalia</option>
-                                                    <option value="South Africa">South Africa</option>
-                                                    <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
-                                                    <option value="Spain">Spain</option>
-                                                    <option value="Sri Lanka">Sri Lanka</option>
-                                                    <option value="Sudan">Sudan</option>
-                                                    <option value="Suriname">Suriname</option>
-                                                    <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
-                                                    <option value="Swaziland">Swaziland</option>
-                                                    <option value="Sweden">Sweden</option>
-                                                    <option value="Switzerland">Switzerland</option>
-                                                    <option value="Syrian Arab Republic">Syrian Arab Republic</option>
-                                                    <option value="Taiwan">Taiwan</option>
-                                                    <option value="Tajikistan">Tajikistan</option>
-                                                    <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
-                                                    <option value="Thailand">Thailand</option>
-                                                    <option value="Togo">Togo</option>
-                                                    <option value="Tokelau">Tokelau</option>
-                                                    <option value="Tonga">Tonga</option>
-                                                    <option value="Trinidad and Tobago">Trinidad and Tobago</option>
-                                                    <option value="Tunisia">Tunisia</option>
-                                                    <option value="Turkey">Turkey</option>
-                                                    <option value="Turkmenistan">Turkmenistan</option>
-                                                    <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
-                                                    <option value="Tuvalu">Tuvalu</option>
-                                                    <option value="Uganda">Uganda</option>
-                                                    <option value="Ukraine">Ukraine</option>
-                                                    <option value="United Arab Emirates">United Arab Emirates</option>
-                                                    <option value="United Kingdom">United Kingdom</option>
-                                                    <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
-                                                    <option value="Uruguay">Uruguay</option>
-                                                    <option value="Uzbekistan">Uzbekistan</option>
-                                                    <option value="Vanuatu">Vanuatu</option>
-                                                    <option value="Venezuela">Venezuela</option>
-                                                    <option value="Viet Nam">Viet Nam</option>
-                                                    <option value="Virgin Islands, British">Virgin Islands, British</option>
-                                                    <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
-                                                    <option value="Wallis and Futuna">Wallis and Futuna</option>
-                                                    <option value="Western Sahara">Western Sahara</option>
-                                                    <option value="Yemen">Yemen</option>
-                                                    <option value="Yugoslavia">Yugoslavia</option>
-                                                    <option value="Zambia">Zambia</option>
-                                                    <option value="Zimbabwe">Zimbabwe</option>
-                                                    <option value="Unknown">Unknown</option>
-                                                </select>
-                                            </div>
+                                <fieldset aria-labelledby="additionalinfo">
+                                    <div class="row">
+                                        <div class="form-group form-group-md col-xs-12 col-md-6">
+                                            <label for="ownerEmail"><span class="weight600">&#42;</span>Email address <a href="#" data-toggle="tooltip" title="The USPTO will use this email address to send correspondence regarding this application or registration. It is critical to ensure this email address is current." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
+                                            <input type="text" class="form-control" id="ownerEmail"   th:value="${owner.email}" >
                                         </div>
-                                    </fieldset>
-                                    <fieldset aria-labelledby="proprietorinfo" id="none-individual-partner-entity-new" style="display: none;">
+                                        <div class="form-group form-group-md col-xs-12 col-md-6">
+                                            <label for="webaddress">Website address</label>
+                                            <input type="text" class="form-control" id="webaddress"  th:value="${owner.webSiteURL}">
+                                        </div>
                                         <div class="row">
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
-                                                <input type="text" class="form-control rounded-borders ge-name" required  value="">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label><span class="weight600">&#42;</span>State where legally organized</label>
-                                                <select class="form-control ge-state">
-                                                    <option value="">Select</option>
-                                                    <option value="Alabama">Alabama</option>
-                                                    <option value="Alaska">Alaska</option>
-                                                    <option value="Arizona">Arizona</option>
-                                                    <option value="Arkansas">Arkansas</option>
-                                                    <option value="California">California</option>
-                                                    <option value="Colorado">Colorado</option>
-                                                    <option value="Connecticut">Connecticut</option>
-                                                    <option value="Delaware">Delaware</option>
-                                                    <option value="District of Columbia">District of Columbia</option>
-                                                    <option value="Florida">Florida</option>
-                                                    <option value="Georgia">Georgia</option>
-                                                    <option value="Hawaii">Hawaii</option>
-                                                    <option value="Idaho">Idaho</option>
-                                                    <option value="Illinois">Illinois</option>
-                                                    <option value="Indiana">Indiana</option>
-                                                    <option value="Iowa">Iowa</option>
-                                                    <option value="Kansas">Kansas</option>
-                                                    <option value="Kentucky">Kentucky</option>
-                                                    <option value="Louisiana">Louisiana</option>
-                                                    <option value="Maine">Maine</option>
-                                                    <option value="Maryland">Maryland</option>
-                                                    <option value="Massachusetts">Massachusetts</option>
-                                                    <option value="Michigan">Michigan</option>
-                                                    <option value="Minnesota">Minnesota</option>
-                                                    <option value="Mississippi">Mississippi</option>
-                                                    <option value="Missouri">Missouri</option>
-                                                    <option value="Montana">Montana</option>
-                                                    <option value="Nebraska">Nebraska</option>
-                                                    <option value="Nevada">Nevada</option>
-                                                    <option value="New Hampshire">New Hampshire</option>
-                                                    <option value="New Jersey">New Jersey</option>
-                                                    <option value="New Mexico">New Mexico</option>
-                                                    <option value="New York">New York</option>
-                                                    <option value="North Carolina">North Carolina</option>
-                                                    <option value="North Dakota">North Dakota</option>
-                                                    <option value="Ohio">Ohio</option>
-                                                    <option value="Oklahoma">Oklahoma</option>
-                                                    <option value="Oregon">Oregon</option>
-                                                    <option value="Pennsylvania">Pennsylvania</option>
-                                                    <option value="Rhode Island">Rhode Island</option>
-                                                    <option value="South Carolina">South Carolina</option>
-                                                    <option value="South Dakota">South Dakota</option>
-                                                    <option value="Tennessee">Tennessee</option>
-                                                    <option value="Texas">Texas</option>
-                                                    <option value="Utah">Utah</option>
-                                                    <option value="Vermont">Vermont</option>
-                                                    <option value="Virginia">Virginia</option>
-                                                    <option value="Washington">Washington</option>
-                                                    <option value="West Virginia">West Virginia</option>
-                                                    <option value="Wisconsin">Wisconsin</option>
-                                                    <option value="Wyoming">Wyoming</option>
-                                                </select>
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label>Type</label>
-                                                <span>
-                                                    <select class="form-control ge-name-type" >
-                                                        <option value="">Select</option>
-                                                        <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
-                                                        <option value="Trading As(TA)">Trading As(TA)</option>
-                                                        <option value="Also Known As(AKA)">Also Known As(AKA)</option>
-                                                        <option value="Formerly">Formerly</option>
+                                            <div class="col-xs-12">
+                                                <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-4">
+                                                    <label for="phonenumbertype">Phone type</label>
+                                                    <select class="form-control" id="phonenumbertype" name="phonenumbertype">
+                                                        <option value="Type">Type</option>
+                                                        <option value="Cell">Cell</option>
+                                                        <option value="Home">Home</option>
+                                                        <option value="Work">Work</option>
+                                                        <option value="Fax">Fax</option>
                                                     </select>
-                                                </span>
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-md-6 col-lg-6">
+                                                    <label for="phone">Phone number</label>
+                                                    <input type="text" class="form-control" id="phone" th:value="${owner.primaryPhonenumber}">
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-md-2 col-lg-2">
+                                                    <label for="extension">Ext.</label>
+                                                    <input type="text" class="form-control" id="extension">
+                                                </div>
                                             </div>
-                                            <div class="form-group form-group-md col-xs-6" style="">
-                                                <label for="nameoftype">Name</label>
-                                                <input type="text" class="form-control partner-alt-name"  name="nameoftype" ><!--needs th:attribute-->
+                                        </div>
+                                        <div class="row" style="display:none; max-height: 1px;">
+                                        </div>
+                                    </div>
+                                </fieldset>
+                                <div class="inlinebuttons btn-group btn-group-justified  owner-form-buttons" role="navigation" aria-label="view previous or next page" id="prevnxt">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm btn-primary fill next" id="doneButton" value="next" >Done
+                                            <div class="round"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
                                             </div>
-                                        </div>
-                                    </fieldset>
-                                </div> <!-- end of arrary dto object -->
-                            </div>
-                        </div>
-                        <!--END hidden content-->
-                        <div class="appendpartner col-xs-12"></div>
-                        <div class="row" id="hideshow_addpartner">
-
-                            <div class="col-xs-12 form-group form-group-md" aria-label="add a partner">
-                                <div class="inlinebuttons btn-group btn-group-justified">
-                                    <div class="btn-group col-xs-6">
-                                        <button type="button" class="btn btn-sm btn-success addinitial" id="addpartner">Add Partner</button>
+                                        </button>
                                     </div>
                                 </div>
-                            </div><!--// add button-->
-                        </div><!--// hide / show add partner-->
-                        <!--END Sole Proprietor Information Form-->
-                        <!--START Owner Address Information Form-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="addressinfo">Owner Address Information</h2>
+                                <!--END Additional Information Form-->
+                            </div><!--END Content Div-->
                         </div>
-                        <fieldset aria-labelledby="addressinfo">
-                            <div class="row">
-                                <div class="form-group form-group-md col-md-12 col-lg-7">
-                                    <label for="OwnerAddressCountry"><span class="weight600">&#42;</span>Country / U.S. territory</label>
-                                    <select class="form-control" id="OwnerAddressCountry" name="territory" th:field="${owner.country}" >
-                                        <option value="">Select</option>
-                                        <option value="United States of America">United States of America</option>
-                                        <option value="Afghanistan">Afghanistan</option>
-                                        <option value="Albania">Albania</option>
-                                        <option value="Algeria">Algeria</option>
-                                        <option value="American Samoa">American Samoa</option>
-                                        <option value="Andorra">Andorra</option>
-                                        <option value="Angola">Angola</option>
-                                        <option value="Anguilla">Anguilla</option>
-                                        <option value="Antarctica">Antarctica</option>
-                                        <option value="Antigua and Barbuda">Antigua and Barbuda</option>
-                                        <option value="Argentina">Argentina</option>
-                                        <option value="Armenia">Armenia</option>
-                                        <option value="Aruba">Aruba</option>
-                                        <option value="Australia">Australia</option>
-                                        <option value="Austria">Austria</option>
-                                        <option value="Azerbaijan">Azerbaijan</option>
-                                        <option value="Bahamas">Bahamas</option>
-                                        <option value="Bahrain">Bahrain</option>
-                                        <option value="Bangladesh">Bangladesh</option>
-                                        <option value="Barbados">Barbados</option>
-                                        <option value="Belarus">Belarus</option>
-                                        <option value="Belgium">Belgium</option>
-                                        <option value="Belize">Belize</option>
-                                        <option value="Benin">Benin</option>
-                                        <option value="Bermuda">Bermuda</option>
-                                        <option value="Bhutan">Bhutan</option>
-                                        <option value="Bolivia">Bolivia</option>
-                                        <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
-                                        <option value="Botswana">Botswana</option>
-                                        <option value="Bouvet Island">Bouvet Island</option>
-                                        <option value="Brazil">Brazil</option>
-                                        <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
-                                        <option value="Brunei Darussalam">Brunei Darussalam</option>
-                                        <option value="Bulgaria">Bulgaria</option>
-                                        <option value="Burkina Faso">Burkina Faso</option>
-                                        <option value="Burundi">Burundi</option>
-                                        <option value="Canada">Canada</option>
-                                        <option value="Cambodia">Cambodia</option>
-                                        <option value="Cameroon">Cameroon</option>
-                                        <option value="Cape Verde">Cape Verde</option>
-                                        <option value="Cayman Islands">Cayman Islands</option>
-                                        <option value="Central African Republic">Central African Republic</option>
-                                        <option value="Chad">Chad</option>
-                                        <option value="Chile">Chile</option>
-                                        <option value="China">China</option>
-                                        <option value="Christmas Island">Christmas Island</option>
-                                        <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
-                                        <option value="Colombia">Colombia</option>
-                                        <option value="Comoros">Comoros</option>
-                                        <option value="Congo">Congo</option>
-                                        <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
-                                        <option value="Cook Islands">Cook Islands</option>
-                                        <option value="Costa Rica">Costa Rica</option>
-                                        <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
-                                        <option value="Croatia">Croatia</option>
-                                        <option value="Cuba">Cuba</option>
-                                        <option value="Cyprus">Cyprus</option>
-                                        <option value="Czech Republic">Czech Republic</option>
-                                        <option value="Denmark">Denmark</option>
-                                        <option value="Djibouti">Djibouti</option>
-                                        <option value="Dominica">Dominica</option>
-                                        <option value="Dominican Republic">Dominican Republic</option>
-                                        <option value="East Timor">East Timor</option>
-                                        <option value="Ecuador">Ecuador</option>
-                                        <option value="Egypt">Egypt</option>
-                                        <option value="El Salvador">El Salvador</option>
-                                        <option value="Equatorial Guinea">Equatorial Guinea</option>
-                                        <option value="Eritrea">Eritrea</option>
-                                        <option value="Estonia">Estonia</option>
-                                        <option value="Ethiopia">Ethiopia</option>
-                                        <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
-                                        <option value="Faroe Islands">Faroe Islands</option>
-                                        <option value="Fiji">Fiji</option>
-                                        <option value="Finland">Finland</option>
-                                        <option value="France">France</option>
-                                        <option value="French Guiana">French Guiana</option>
-                                        <option value="French Polynesia">French Polynesia</option>
-                                        <option value="French Southern Territories">French Southern Territories</option>
-                                        <option value="Gabon">Gabon</option>
-                                        <option value="Gambia">Gambia</option>
-                                        <option value="Georgia">Georgia</option>
-                                        <option value="Germany">Germany</option>
-                                        <option value="Ghana">Ghana</option>
-                                        <option value="Gibraltar">Gibraltar</option>
-                                        <option value="Greece">Greece</option>
-                                        <option value="Greenland">Greenland</option>
-                                        <option value="Grenada">Grenada</option>
-                                        <option value="Guadeloupe">Guadeloupe</option>
-                                        <option value="Guam">Guam</option>
-                                        <option value="Guatemala">Guatemala</option>
-                                        <option value="Guinea">Guinea</option>
-                                        <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
-                                        <option value="Guyana">Guyana</option>
-                                        <option value="Haiti">Haiti</option>
-                                        <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
-                                        <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
-                                        <option value="Honduras">Honduras</option>
-                                        <option value="Hong Kong">Hong Kong</option>
-                                        <option value="Hungary">Hungary</option>
-                                        <option value="Iceland">Iceland</option>
-                                        <option value="India">India</option>
-                                        <option value="Indonesia">Indonesia</option>
-                                        <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
-                                        <option value="Iraq">Iraq</option>
-                                        <option value="Ireland">Ireland</option>
-                                        <option value="Israel">Israel</option>
-                                        <option value="Italy">Italy</option>
-                                        <option value="Jamaica">Jamaica</option>
-                                        <option value="Japan">Japan</option>
-                                        <option value="Jordan">Jordan</option>
-                                        <option value="Kazakstan">Kazakstan</option>
-                                        <option value="Kenya">Kenya</option>
-                                        <option value="Kiribati">Kiribati</option>
-                                        <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
-                                        <option value="Korea, Republic of">Korea, Republic of</option>
-                                        <option value="Kuwait">Kuwait</option>
-                                        <option value="Kyrgyzstan">Kyrgyzstan</option>
-                                        <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
-                                        <option value="Latvia">Latvia</option>
-                                        <option value="Lebanon">Lebanon</option>
-                                        <option value="Lesotho">Lesotho</option>
-                                        <option value="Liberia">Liberia</option>
-                                        <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
-                                        <option value="Liechtenstein">Liechtenstein</option>
-                                        <option value="Lithuania">Lithuania</option>
-                                        <option value="Luxembourg">Luxembourg</option>
-                                        <option value="Macau">Macau</option>
-                                        <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
-                                        <option value="Madagascar">Madagascar</option>
-                                        <option value="Malawi">Malawi</option>
-                                        <option value="Malaysia">Malaysia</option>
-                                        <option value="Maldives">Maldives</option>
-                                        <option value="Mali">Mali</option>
-                                        <option value="Malta">Malta</option>
-                                        <option value="Marshall Islands">Marshall Islands</option>
-                                        <option value="Martinique">Martinique</option>
-                                        <option value="Mauritania">Mauritania</option>
-                                        <option value="Mauritius">Mauritius</option>
-                                        <option value="Mayotte">Mayotte</option>
-                                        <option value="Mexico">Mexico</option>
-                                        <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
-                                        <option value="Moldova, Republic of">Moldova, Republic of</option>
-                                        <option value="Monaco">Monaco</option>
-                                        <option value="Mongolia">Mongolia</option>
-                                        <option value="Montserrat">Montserrat</option>
-                                        <option value="Morocco">Morocco</option>
-                                        <option value="Mozambique">Mozambique</option>
-                                        <option value="Myanmar">Myanmar</option>
-                                        <option value="Namibia">Namibia</option>
-                                        <option value="Nauru">Nauru</option>
-                                        <option value="Nepal">Nepal</option>
-                                        <option value="Netherlands">Netherlands</option>
-                                        <option value="Netherlands Antilles">Netherlands Antilles</option>
-                                        <option value="New Caledonia">New Caledonia</option>
-                                        <option value="New Zealand">New Zealand</option>
-                                        <option value="Nicaragua">Nicaragua</option>
-                                        <option value="Niger">Niger</option>
-                                        <option value="Nigeria">Nigeria</option>
-                                        <option value="Niue">Niue</option>
-                                        <option value="Norfolk Island">Norfolk Island</option>
-                                        <option value="Northern Mariana Islands">Northern Mariana Islands</option>
-                                        <option value="Norway">Norway</option>
-                                        <option value="Oman">Oman</option>
-                                        <option value="Pakistan">Pakistan</option>
-                                        <option value="Palau">Palau</option>
-                                        <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
-                                        <option value="Panama">Panama</option>
-                                        <option value="Papua New Guinea">Papua New Guinea</option>
-                                        <option value="Paraguay">Paraguay</option>
-                                        <option value="Peru">Peru</option>
-                                        <option value="Philippines">Philippines</option>
-                                        <option value="Pitcairn">Pitcairn</option>
-                                        <option value="Poland">Poland</option>
-                                        <option value="Portugal">Portugal</option>
-                                        <option value="Puerto Rico">Puerto Rico</option>
-                                        <option value="Qatar">Qatar</option>
-                                        <option value="Reunion">Reunion</option>
-                                        <option value="Romania">Romania</option>
-                                        <option value="Russian Federation">Russian Federation</option>
-                                        <option value="Rwanda">Rwanda</option>
-                                        <option value="Saint Helena">Saint Helena</option>
-                                        <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
-                                        <option value="Saint Lucia">Saint Lucia</option>
-                                        <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
-                                        <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
-                                        <option value="Samoa">Samoa</option>
-                                        <option value="San Marino">San Marino</option>
-                                        <option value="Sao Tome and Principe">Sao Tome and Principe</option>
-                                        <option value="Saudi Arabia">Saudi Arabia</option>
-                                        <option value="Senegal">Senegal</option>
-                                        <option value="Seychelles">Seychelles</option>
-                                        <option value="Sierra Leone">Sierra Leone</option>
-                                        <option value="Singapore">Singapore</option>
-                                        <option value="Slovakia">Slovakia</option>
-                                        <option value="Slovenia">Slovenia</option>
-                                        <option value="Solomon Islands">Solomon Islands</option>
-                                        <option value="Somalia">Somalia</option>
-                                        <option value="South Africa">South Africa</option>
-                                        <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
-                                        <option value="Spain">Spain</option>
-                                        <option value="Sri Lanka">Sri Lanka</option>
-                                        <option value="Sudan">Sudan</option>
-                                        <option value="Suriname">Suriname</option>
-                                        <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
-                                        <option value="Swaziland">Swaziland</option>
-                                        <option value="Sweden">Sweden</option>
-                                        <option value="Switzerland">Switzerland</option>
-                                        <option value="Syrian Arab Republic">Syrian Arab Republic</option>
-                                        <option value="Taiwan">Taiwan</option>
-                                        <option value="Tajikistan">Tajikistan</option>
-                                        <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
-                                        <option value="Thailand">Thailand</option>
-                                        <option value="Togo">Togo</option>
-                                        <option value="Tokelau">Tokelau</option>
-                                        <option value="Tonga">Tonga</option>
-                                        <option value="Trinidad and Tobago">Trinidad and Tobago</option>
-                                        <option value="Tunisia">Tunisia</option>
-                                        <option value="Turkey">Turkey</option>
-                                        <option value="Turkmenistan">Turkmenistan</option>
-                                        <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
-                                        <option value="Tuvalu">Tuvalu</option>
-                                        <option value="Uganda">Uganda</option>
-                                        <option value="Ukraine">Ukraine</option>
-                                        <option value="United Arab Emirates">United Arab Emirates</option>
-                                        <option value="United Kingdom">United Kingdom</option>
-                                        <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
-                                        <option value="Uruguay">Uruguay</option>
-                                        <option value="Uzbekistan">Uzbekistan</option>
-                                        <option value="Vanuatu">Vanuatu</option>
-                                        <option value="Venezuela">Venezuela</option>
-                                        <option value="Viet Nam">Viet Nam</option>
-                                        <option value="Virgin Islands, British">Virgin Islands, British</option>
-                                        <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
-                                        <option value="Wallis and Futuna">Wallis and Futuna</option>
-                                        <option value="Western Sahara">Western Sahara</option>
-                                        <option value="Yemen">Yemen</option>
-                                        <option value="Yugoslavia">Yugoslavia</option>
-                                        <option value="Zambia">Zambia</option>
-                                        <option value="Zimbabwe">Zimbabwe</option>
-                                        <option value="Unknown">Unknown</option>
-                                    </select>
-                                </div>
-                                <div class="form-group form-group-md col-md-12 col-lg-9">
-                                    <label for="ownerAddress1"><span class="weight600">&#42;</span>Address line 1</label>
-                                    <input type="text" class="form-control" id="ownerAddress1" th:value="${owner.address1}" >
-                                </div>
-                                <div class="form-group form-group-md col-md-12 col-lg-9">
-                                    <label for="addressline2">Address line 2</label>
-                                    <input type="text" class="form-control" id="addressline2" >
-                                </div>
-                                <div class="form-group form-group-md col-md-12 col-lg-9">
-                                    <label for="addressline3">Address line 3</label>
-                                    <input type="text" class="form-control" id="addressline3" >
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                    <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
-                                    <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}">
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                    <label for="ownerState"><span class="weight600">&#42;</span>State/Province/Territory</label>
-                                    <select class="form-control" id="ownerState" th:field="${owner.state}" required>
-                                        <option value="">Select</option>
-                                        <option value="Alabama">Alabama</option>
-                                        <option value="Alaska">Alaska</option>
-                                        <option value="Arizona">Arizona</option>
-                                        <option value="Arkansas">Arkansas</option>
-                                        <option value="California">California</option>
-                                        <option value="Colorado">Colorado</option>
-                                        <option value="Connecticut">Connecticut</option>
-                                        <option value="Delaware">Delaware</option>
-                                        <option value="District of Columbia">District of Columbia</option>
-                                        <option value="Florida">Florida</option>
-                                        <option value="Georgia">Georgia</option>
-                                        <option value="Hawaii">Hawaii</option>
-                                        <option value="Idaho">Idaho</option>
-                                        <option value="Illinois">Illinois</option>
-                                        <option value="Indiana">Indiana</option>
-                                        <option value="Iowa">Iowa</option>
-                                        <option value="Kansas">Kansas</option>
-                                        <option value="Kentucky">Kentucky</option>
-                                        <option value="Louisiana">Louisiana</option>
-                                        <option value="Maine">Maine</option>
-                                        <option value="Maryland">Maryland</option>
-                                        <option value="Massachusetts">Massachusetts</option>
-                                        <option value="Michigan">Michigan</option>
-                                        <option value="Minnesota">Minnesota</option>
-                                        <option value="Mississippi">Mississippi</option>
-                                        <option value="Missouri">Missouri</option>
-                                        <option value="Montana">Montana</option>
-                                        <option value="Nebraska">Nebraska</option>
-                                        <option value="Nevada">Nevada</option>
-                                        <option value="New Hampshire">New Hampshire</option>
-                                        <option value="New Jersey">New Jersey</option>
-                                        <option value="New Mexico">New Mexico</option>
-                                        <option value="New York">New York</option>
-                                        <option value="North Carolina">North Carolina</option>
-                                        <option value="North Dakota">North Dakota</option>
-                                        <option value="Ohio">Ohio</option>
-                                        <option value="Oklahoma">Oklahoma</option>
-                                        <option value="Oregon">Oregon</option>
-                                        <option value="Pennsylvania">Pennsylvania</option>
-                                        <option value="Rhode Island">Rhode Island</option>
-                                        <option value="South Carolina">South Carolina</option>
-                                        <option value="South Dakota">South Dakota</option>
-                                        <option value="Tennessee">Tennessee</option>
-                                        <option value="Texas">Texas</option>
-                                        <option value="Utah">Utah</option>
-                                        <option value="Vermont">Vermont</option>
-                                        <option value="Virginia">Virginia</option>
-                                        <option value="Washington">Washington</option>
-                                        <option value="West Virginia">West Virginia</option>
-                                        <option value="Wisconsin">Wisconsin</option>
-                                        <option value="Wyoming">Wyoming</option>
-                                    </select>
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-5">
-                                    <label for="ownerZipcode"><span class="weight600">&#42;</span>Zip code/Postal code</label>
-                                    <input type="text" class="form-control" id="ownerZipcode" placeholder=""  th:value="${owner.zipcode}">
-                                </div>
-                            </div>
-                        </fieldset>
-                        <!--END Owner Address Information Form-->
-                        <!--START Additional Information Form-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="additionalinfo">Additional Information</h2>
-                        </div>
-                        <fieldset aria-labelledby="additionalinfo">
-                            <div class="row">
-                                <div class="form-group form-group-md col-xs-12 col-md-6">
-                                    <label for="ownerEmail"><span class="weight600">&#42;</span>Email address <a href="#" data-toggle="tooltip" title="The USPTO will use this email address to send correspondence regarding this application or registration. It is critical to ensure this email address is current." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
-                                    <input type="text" class="form-control" id="ownerEmail"   th:value="${owner.email}" >
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-md-6">
-                                    <label for="webaddress">Website address</label>
-                                    <input type="text" class="form-control" id="webaddress"  th:value="${owner.webSiteURL}">
-                                </div>
-                                <div class="row">
-                                    <div class="col-xs-12">
-                                        <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-4">
-                                            <label for="phonenumbertype">Phone type</label>
-                                            <select class="form-control" id="phonenumbertype" name="phonenumbertype">
-                                                <option value="Type">Type</option>
-                                                <option value="Cell">Cell</option>
-                                                <option value="Home">Home</option>
-                                                <option value="Work">Work</option>
-                                                <option value="Fax">Fax</option>
-                                            </select>
-                                        </div>
-                                        <div class="form-group form-group-md col-xs-12 col-md-6 col-lg-6">
-                                            <label for="phone">Phone number</label>
-                                            <input type="text" class="form-control" id="phone" th:value="${owner.primaryPhonenumber}">
-                                        </div>
-                                        <div class="form-group form-group-md col-xs-12 col-md-2 col-lg-2">
-                                            <label for="extension">Ext.</label>
-                                            <input type="text" class="form-control" id="extension">
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="row" style="display:none; max-height: 1px;">
-                                </div>
-                            </div>
-                        </fieldset>
-                        <div class="inlinebuttons btn-group btn-group-justified  owner-form-buttons" role="navigation" aria-label="view previous or next page" id="prevnxt">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm btn-primary fill next" id="doneButton" value="next" >Done
-                                    <div class="round"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
-                                    </div>
-                                </button>
-                            </div>
-                        </div>
-                        <!--END Additional Information Form-->
-                    </div><!--END Content Div-->
+                    </div><!--END container div-->
                 </div>
-            </div><!--END container div-->
+            </main>
         </div>
-    </main>
-</div>
+    </div>
 <!--load model attribute for Jquery consumption  -->
 <script th:inline="javascript">
 

--- a/PTO-WEB/src/main/resources/templates/application/owner/individual/ownerInfo2.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/individual/ownerInfo2.html
@@ -60,7 +60,7 @@
                                 </select>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                 <select class="form-control" name="nameType"  th:field="*{ownerType}" id="additional-name-type"><!--Needs th:attribute-->
                                     <option value="">Select</option>
                                     <option value="dba">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/owner/individual/ownerInfoEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/individual/ownerInfoEdit.html
@@ -107,7 +107,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="suffix">Suffix</label>
-                                    <select class="form-control" name="suffix"   id="suffix" th:field="${owner.suffix}">
+                                    <select class="form-control" name="suffix" id="suffix" th:field="${owner.suffix}">
                                         <option value="select">Select</option>
                                         <option value="Sr.">Sr.</option>
                                         <option value="I">I</option>
@@ -129,7 +129,7 @@
                                     </select>
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" name="nameType"   id="additional-name-type"  th:field="${owner.ownerType}"><!--Needs th:attribute-->
                                         <option value="">Select</option>
                                         <option value="dba">Doing Business As (DBA)</option>
@@ -148,7 +148,7 @@
 
                                 </th:block>
                                 <th:block  th:if="${owner.isAlternameSet() == false}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype" style="display:none;">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype" style="display:none;">
                                         <label for="nameoftype">Name</label>
                                         <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
                                     </div>

--- a/PTO-WEB/src/main/resources/templates/application/owner/jointVC/ownerInfo.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/jointVC/ownerInfo.html
@@ -29,7 +29,7 @@
                                 <input type="text" class="form-control"  id="ownername" th:field="*{ownerName}" required>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                <label for="stateoforg">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                <label for="stateoforg">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                 <select class="form-control" id="stateoforg" th:field="*{ownerOrganizationState}" required>
                                     <option value="">Select</option>
                                     <option value="Alabama">Alabama</option>
@@ -87,7 +87,7 @@
                                 </select>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                 <select class="form-control" id="additional-name-type" th:field="*{ownerType}">
                                     <option value="">Select</option>
                                     <option value="DBA">Doing Business As (DBA)</option>
@@ -403,7 +403,7 @@
                                     <input id="partner-owner-name" type="text" th:field="*{partnerDTOs[__${itemStat.index}__].partnerName}"  class="form-control rounded-borders"   required>
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="partner-owner-name-state">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label for="partner-owner-name-state">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select  id="partner-owner-name-state" th:field="*{partnerDTOs[__${itemStat.index}__].state}"  class="form-control" name="State">
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>
@@ -513,7 +513,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input  class="form-control" id="partner-suffix2" name="suffix" th:field="*{partner_suffix2}" />
+                                    <input type="text" class="form-control" id="partner-suffix2" name="suffix" th:field="*{partner_suffix2}" />
 
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
@@ -771,7 +771,7 @@
                                     <input id="partner-owner-name2" type="text" class="form-control rounded-borders" th:field="*{partner_name2}"  >
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="partner-owner-name-state2">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label for="partner-owner-name-state2">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select id="partner-owner-name-state2" class="form-control" name="State" th:field="*{partner_state_org2}"  >
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>
@@ -880,7 +880,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input class="form-control" id="partner-suffix3" name="suffix" th:field="*{partner_suffix3}" />
+                                    <input type="text" class="form-control" id="partner-suffix3" name="suffix" th:field="*{partner_suffix3}" />
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
                                     <label for="partner-citizenship">Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
@@ -1137,7 +1137,7 @@
                                     <input id="partner-owner-name3" type="text"  class="form-control rounded-borders"   th:field="*{partner_name3}"  >
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="partner-owner-name-state3">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label for="partner-owner-name-state3">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select  id="partner-owner-name-state3"  class="form-control" name="State"   th:field="*{partner_state_org3}" >
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>

--- a/PTO-WEB/src/main/resources/templates/application/owner/jointVC/ownerInfoEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/jointVC/ownerInfoEdit.html
@@ -7,214 +7,937 @@
     <title>Owner Information</title>
 </head>
 <body>
-<div class="row content"  style="display: none;">
-    <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
-        <div class="row" >
-            <div class="col-xs-12">
-                <!--START Content Div-->
-                <div class="row">
-                    <section class="col-xs-12 steps breadcrumb-steps" aria-label="progress tracker">
-                        <div class="row displaycell">
-                            <div class="col-xs-2 one" id="bs-header1">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>1</span>
+    <div class="container-fluid">
+        <div class="row content"  style="display: none;">
+            <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
+                <div class="row" >
+                    <div class="col-xs-12">
+                        <!--START Content Div-->
+                        <div class="row">
+                            <section class="col-xs-12 steps breadcrumb-steps" aria-label="progress tracker">
+                                <div class="row displaycell">
+                                    <div class="col-xs-2 one" id="bs-header1">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>1</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link1">
+                                                <p class="first">Your details</p>
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link1">
-                                        <p class="first">Your details</p>
+                                    <div class="col-xs-2 two" id="bs-header2">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>2</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link2">
+                                                <p>Trademark details</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 three" id="bs-header3">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>3</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link3">
+                                                <p>Goods and services</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 four" id="bs-header4">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>4</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link4">
+                                                <p>Basis</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 five" id="bs-header5">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>5</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link5">
+                                                <p>Additional info</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 six" id="bs-header6">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>6</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link6">
+                                                <p>Confirm and pay</p>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-xs-2 two" id="bs-header2">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>2</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link2">
-                                        <p>Trademark details</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 three" id="bs-header3">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>3</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link3">
-                                        <p>Goods and services</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 four" id="bs-header4">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>4</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link4">
-                                        <p>Basis</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 five" id="bs-header5">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>5</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link5">
-                                        <p>Additional info</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 six" id="bs-header6">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>6</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link6">
-                                        <p>Confirm and pay</p>
-                                    </div>
-                                </div>
-                            </div>
+                            </section>
                         </div>
-                    </section>
-                </div>
-                <div class="row" style="">
+                        <div class="row" style="">
 
-                    <div class="row">
-                        <div class="col-xs-6">
-                            <h1 style="margin-left: 15px;">Edit Owner Information</h1>
-                        </div>
-                    </div>
-                    <div class="col-xs-12 text-left">
-                        <!--START Owner Information Form-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="ownerinfo">Owner Information</h2>
-                        </div>
-                        <fieldset aria-labelledby="ownerinfo">
                             <div class="row">
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
-                                    <input type="text" class="form-control"  id="ownername"  th:value="${owner.ownerDisplayname}">
+                                <div class="col-xs-6">
+                                    <h1 style="margin-left: 15px;">Edit Owner Information</h1>
                                 </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-9">
-                                    <label for="stateoforg"><span class="weight600">&#42;</span>State where legally organized <span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
-                                    <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}" >
-                                        <option value="">Select</option>
-                                        <option value="Alabama">Alabama</option>
-                                        <option value="Alaska">Alaska</option>
-                                        <option value="Arizona">Arizona</option>
-                                        <option value="Arkansas">Arkansas</option>
-                                        <option value="California">California</option>
-                                        <option value="Colorado">Colorado</option>
-                                        <option value="Connecticut">Connecticut</option>
-                                        <option value="Delaware">Delaware</option>
-                                        <option value="District of Columbia">District of Columbia</option>
-                                        <option value="Florida">Florida</option>
-                                        <option value="Georgia">Georgia</option>
-                                        <option value="Hawaii">Hawaii</option>
-                                        <option value="Idaho">Idaho</option>
-                                        <option value="Illinois">Illinois</option>
-                                        <option value="Indiana">Indiana</option>
-                                        <option value="Iowa">Iowa</option>
-                                        <option value="Kansas">Kansas</option>
-                                        <option value="Kentucky">Kentucky</option>
-                                        <option value="Louisiana">Louisiana</option>
-                                        <option value="Maine">Maine</option>
-                                        <option value="Maryland">Maryland</option>
-                                        <option value="Massachusetts">Massachusetts</option>
-                                        <option value="Michigan">Michigan</option>
-                                        <option value="Minnesota">Minnesota</option>
-                                        <option value="Mississippi">Mississippi</option>
-                                        <option value="Missouri">Missouri</option>
-                                        <option value="Montana">Montana</option>
-                                        <option value="Nebraska">Nebraska</option>
-                                        <option value="Nevada">Nevada</option>
-                                        <option value="New Hampshire">New Hampshire</option>
-                                        <option value="New Jersey">New Jersey</option>
-                                        <option value="New Mexico">New Mexico</option>
-                                        <option value="New York">New York</option>
-                                        <option value="North Carolina">North Carolina</option>
-                                        <option value="North Dakota">North Dakota</option>
-                                        <option value="Ohio">Ohio</option>
-                                        <option value="Oklahoma">Oklahoma</option>
-                                        <option value="Oregon">Oregon</option>
-                                        <option value="Pennsylvania">Pennsylvania</option>
-                                        <option value="Rhode Island">Rhode Island</option>
-                                        <option value="South Carolina">South Carolina</option>
-                                        <option value="South Dakota">South Dakota</option>
-                                        <option value="Tennessee">Tennessee</option>
-                                        <option value="Texas">Texas</option>
-                                        <option value="Utah">Utah</option>
-                                        <option value="Vermont">Vermont</option>
-                                        <option value="Virginia">Virginia</option>
-                                        <option value="Washington">Washington</option>
-                                        <option value="West Virginia">West Virginia</option>
-                                        <option value="Wisconsin">Wisconsin</option>
-                                        <option value="Wyoming">Wyoming</option>
-                                    </select>
-                                </div>
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
-                                    <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
-                                        <option value="Select">Select</option>
-                                        <option value="DBA">Doing Business As (DBA)</option>
-                                        <option value="TA">Trading As (TA)</option>
-                                        <option value="AKA">Also Known As (AKA)</option>
-                                        <option value="Formerly">Formerly</option>
-                                    </select>
-                                </div>
-
-
-                                <th:block  th:if="${owner.isAlternameSet() == true}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype">
-                                        <label for="nameoftype">Name</label>
-                                        <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
-                                    </div>
-                                </th:block>
-
-                                <th:block  th:if="${owner.isAlternameSet() == false}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype" style="display: none;">
-                                        <label for="nameoftype">Name</label>
-                                        <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
-                                    </div>
-                                </th:block>
-
                             </div>
-                        </fieldset>
-                        <!--END Owner Information-->
-                        <!--START Sole Proprietor Information-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="proprietorinfo">Active Member Information</h2>
-                        </div>
-                        <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity" style="">
-                            <th:block th:each="exceuter, iter : ${governingEntity}">
-                                <div class="row">
-                                    <th:block th:if="${exceuter.isPrimaryGoverningEntity() == false}">
-                                        <div class="form-group form-group-md col-xs-12 removepartner">
-                                            <button type="button" class="btn btn-sm close removepartner" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
+                            <div class="col-xs-12 text-left">
+                                <!--START Owner Information Form-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="ownerinfo">Owner Information</h2>
+                                </div>
+                                <fieldset aria-labelledby="ownerinfo">
+                                    <div class="row">
+                                        <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                            <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
+                                            <input type="text" class="form-control"  id="ownername"  th:value="${owner.ownerDisplayname}">
                                         </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                            <label for="stateoforg">State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
+                                            <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}" >
+                                                <option value="">Select</option>
+                                                <option value="Alabama">Alabama</option>
+                                                <option value="Alaska">Alaska</option>
+                                                <option value="Arizona">Arizona</option>
+                                                <option value="Arkansas">Arkansas</option>
+                                                <option value="California">California</option>
+                                                <option value="Colorado">Colorado</option>
+                                                <option value="Connecticut">Connecticut</option>
+                                                <option value="Delaware">Delaware</option>
+                                                <option value="District of Columbia">District of Columbia</option>
+                                                <option value="Florida">Florida</option>
+                                                <option value="Georgia">Georgia</option>
+                                                <option value="Hawaii">Hawaii</option>
+                                                <option value="Idaho">Idaho</option>
+                                                <option value="Illinois">Illinois</option>
+                                                <option value="Indiana">Indiana</option>
+                                                <option value="Iowa">Iowa</option>
+                                                <option value="Kansas">Kansas</option>
+                                                <option value="Kentucky">Kentucky</option>
+                                                <option value="Louisiana">Louisiana</option>
+                                                <option value="Maine">Maine</option>
+                                                <option value="Maryland">Maryland</option>
+                                                <option value="Massachusetts">Massachusetts</option>
+                                                <option value="Michigan">Michigan</option>
+                                                <option value="Minnesota">Minnesota</option>
+                                                <option value="Mississippi">Mississippi</option>
+                                                <option value="Missouri">Missouri</option>
+                                                <option value="Montana">Montana</option>
+                                                <option value="Nebraska">Nebraska</option>
+                                                <option value="Nevada">Nevada</option>
+                                                <option value="New Hampshire">New Hampshire</option>
+                                                <option value="New Jersey">New Jersey</option>
+                                                <option value="New Mexico">New Mexico</option>
+                                                <option value="New York">New York</option>
+                                                <option value="North Carolina">North Carolina</option>
+                                                <option value="North Dakota">North Dakota</option>
+                                                <option value="Ohio">Ohio</option>
+                                                <option value="Oklahoma">Oklahoma</option>
+                                                <option value="Oregon">Oregon</option>
+                                                <option value="Pennsylvania">Pennsylvania</option>
+                                                <option value="Rhode Island">Rhode Island</option>
+                                                <option value="South Carolina">South Carolina</option>
+                                                <option value="South Dakota">South Dakota</option>
+                                                <option value="Tennessee">Tennessee</option>
+                                                <option value="Texas">Texas</option>
+                                                <option value="Utah">Utah</option>
+                                                <option value="Vermont">Vermont</option>
+                                                <option value="Virginia">Virginia</option>
+                                                <option value="Washington">Washington</option>
+                                                <option value="West Virginia">West Virginia</option>
+                                                <option value="Wisconsin">Wisconsin</option>
+                                                <option value="Wyoming">Wyoming</option>
+                                            </select>
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                            <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                            <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
+                                                <option value="Select">Select</option>
+                                                <option value="DBA">Doing Business As (DBA)</option>
+                                                <option value="TA">Trading As (TA)</option>
+                                                <option value="AKA">Also Known As (AKA)</option>
+                                                <option value="Formerly">Formerly</option>
+                                            </select>
+                                        </div>
+
+
+                                        <th:block  th:if="${owner.isAlternameSet() == true}">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype">
+                                                <label for="nameoftype">Name</label>
+                                                <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
+                                            </div>
+                                        </th:block>
+
+                                        <th:block  th:if="${owner.isAlternameSet() == false}">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype" style="display: none;">
+                                                <label for="nameoftype">Name</label>
+                                                <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
+                                            </div>
+                                        </th:block>
+
+                                    </div>
+                                </fieldset>
+                                <!--END Owner Information-->
+                                <!--START Sole Proprietor Information-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="proprietorinfo">Active Member Information</h2>
+                                </div>
+                                <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity" style="">
+                                    <th:block th:each="exceuter, iter : ${governingEntity}">
+                                        <div class="row">
+                                            <th:block th:if="${exceuter.isPrimaryGoverningEntity() == false}">
+                                                <div class="form-group form-group-md col-xs-12 removepartner">
+                                                    <button type="button" class="btn btn-sm close removepartner" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
+                                                </div>
+                                            </th:block>
+                                            <th:block th:if="${exceuter.isPersonEntity() == true}">
+                                                <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
+                                                    <label><span class="weight600">&#42;</span>First name</label>
+                                                    <input type="text" name="firstName" class="form-control ge-first-name" th:value="${exceuter.firstName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}" >
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
+                                                    <label>Middle name</label>
+                                                    <input type="text" name="middleName" class="form-control ge-middle-name" th:value="${exceuter.middleName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
+                                                    <label><span class="weight600">&#42;</span>Last name</label>
+                                                    <input type="text" name="lastName" class="form-control ge-last-name" th:value="${exceuter.lastName}"   th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
+                                                    <label>Suffix</label>
+                                                    <input type="text" class="form-control ge-suffix" name="suffix" />
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
+                                                    <label>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                                    <select class="form-control ge-citizenship" name="owner-citizenship" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                        <option th:value="${exceuter.entityCitizenship}" th:text="${exceuter.entityCitizenship}" selected  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"></option>
+                                                        <option value="">Select</option>
+                                                        <option value="United States of America">United States of America</option>
+                                                        <option value="Afghanistan">Afghanistan</option>
+                                                        <option value="Albania">Albania</option>
+                                                        <option value="Algeria">Algeria</option>
+                                                        <option value="American Samoa">American Samoa</option>
+                                                        <option value="Andorra">Andorra</option>
+                                                        <option value="Angola">Angola</option>
+                                                        <option value="Anguilla">Anguilla</option>
+                                                        <option value="Antarctica">Antarctica</option>
+                                                        <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+                                                        <option value="Argentina">Argentina</option>
+                                                        <option value="Armenia">Armenia</option>
+                                                        <option value="Aruba">Aruba</option>
+                                                        <option value="Australia">Australia</option>
+                                                        <option value="Austria">Austria</option>
+                                                        <option value="Azerbaijan">Azerbaijan</option>
+                                                        <option value="Bahamas">Bahamas</option>
+                                                        <option value="Bahrain">Bahrain</option>
+                                                        <option value="Bangladesh">Bangladesh</option>
+                                                        <option value="Barbados">Barbados</option>
+                                                        <option value="Belarus">Belarus</option>
+                                                        <option value="Belgium">Belgium</option>
+                                                        <option value="Belize">Belize</option>
+                                                        <option value="Benin">Benin</option>
+                                                        <option value="Bermuda">Bermuda</option>
+                                                        <option value="Bhutan">Bhutan</option>
+                                                        <option value="Bolivia">Bolivia</option>
+                                                        <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+                                                        <option value="Botswana">Botswana</option>
+                                                        <option value="Bouvet Island">Bouvet Island</option>
+                                                        <option value="Brazil">Brazil</option>
+                                                        <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+                                                        <option value="Brunei Darussalam">Brunei Darussalam</option>
+                                                        <option value="Bulgaria">Bulgaria</option>
+                                                        <option value="Burkina Faso">Burkina Faso</option>
+                                                        <option value="Burundi">Burundi</option>
+                                                        <option value="Canada">Canada</option>
+                                                        <option value="Cambodia">Cambodia</option>
+                                                        <option value="Cameroon">Cameroon</option>
+                                                        <option value="Cape Verde">Cape Verde</option>
+                                                        <option value="Cayman Islands">Cayman Islands</option>
+                                                        <option value="Central African Republic">Central African Republic</option>
+                                                        <option value="Chad">Chad</option>
+                                                        <option value="Chile">Chile</option>
+                                                        <option value="China">China</option>
+                                                        <option value="Christmas Island">Christmas Island</option>
+                                                        <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+                                                        <option value="Colombia">Colombia</option>
+                                                        <option value="Comoros">Comoros</option>
+                                                        <option value="Congo">Congo</option>
+                                                        <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
+                                                        <option value="Cook Islands">Cook Islands</option>
+                                                        <option value="Costa Rica">Costa Rica</option>
+                                                        <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
+                                                        <option value="Croatia">Croatia</option>
+                                                        <option value="Cuba">Cuba</option>
+                                                        <option value="Cyprus">Cyprus</option>
+                                                        <option value="Czech Republic">Czech Republic</option>
+                                                        <option value="Denmark">Denmark</option>
+                                                        <option value="Djibouti">Djibouti</option>
+                                                        <option value="Dominica">Dominica</option>
+                                                        <option value="Dominican Republic">Dominican Republic</option>
+                                                        <option value="East Timor">East Timor</option>
+                                                        <option value="Ecuador">Ecuador</option>
+                                                        <option value="Egypt">Egypt</option>
+                                                        <option value="El Salvador">El Salvador</option>
+                                                        <option value="Equatorial Guinea">Equatorial Guinea</option>
+                                                        <option value="Eritrea">Eritrea</option>
+                                                        <option value="Estonia">Estonia</option>
+                                                        <option value="Ethiopia">Ethiopia</option>
+                                                        <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+                                                        <option value="Faroe Islands">Faroe Islands</option>
+                                                        <option value="Fiji">Fiji</option>
+                                                        <option value="Finland">Finland</option>
+                                                        <option value="France">France</option>
+                                                        <option value="French Guiana">French Guiana</option>
+                                                        <option value="French Polynesia">French Polynesia</option>
+                                                        <option value="French Southern Territories">French Southern Territories</option>
+                                                        <option value="Gabon">Gabon</option>
+                                                        <option value="Gambia">Gambia</option>
+                                                        <option value="Georgia">Georgia</option>
+                                                        <option value="Germany">Germany</option>
+                                                        <option value="Ghana">Ghana</option>
+                                                        <option value="Gibraltar">Gibraltar</option>
+                                                        <option value="Greece">Greece</option>
+                                                        <option value="Greenland">Greenland</option>
+                                                        <option value="Grenada">Grenada</option>
+                                                        <option value="Guadeloupe">Guadeloupe</option>
+                                                        <option value="Guam">Guam</option>
+                                                        <option value="Guatemala">Guatemala</option>
+                                                        <option value="Guinea">Guinea</option>
+                                                        <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
+                                                        <option value="Guyana">Guyana</option>
+                                                        <option value="Haiti">Haiti</option>
+                                                        <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+                                                        <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+                                                        <option value="Honduras">Honduras</option>
+                                                        <option value="Hong Kong">Hong Kong</option>
+                                                        <option value="Hungary">Hungary</option>
+                                                        <option value="Iceland">Iceland</option>
+                                                        <option value="India">India</option>
+                                                        <option value="Indonesia">Indonesia</option>
+                                                        <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+                                                        <option value="Iraq">Iraq</option>
+                                                        <option value="Ireland">Ireland</option>
+                                                        <option value="Israel">Israel</option>
+                                                        <option value="Italy">Italy</option>
+                                                        <option value="Jamaica">Jamaica</option>
+                                                        <option value="Japan">Japan</option>
+                                                        <option value="Jordan">Jordan</option>
+                                                        <option value="Kazakstan">Kazakstan</option>
+                                                        <option value="Kenya">Kenya</option>
+                                                        <option value="Kiribati">Kiribati</option>
+                                                        <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
+                                                        <option value="Korea, Republic of">Korea, Republic of</option>
+                                                        <option value="Kuwait">Kuwait</option>
+                                                        <option value="Kyrgyzstan">Kyrgyzstan</option>
+                                                        <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
+                                                        <option value="Latvia">Latvia</option>
+                                                        <option value="Lebanon">Lebanon</option>
+                                                        <option value="Lesotho">Lesotho</option>
+                                                        <option value="Liberia">Liberia</option>
+                                                        <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
+                                                        <option value="Liechtenstein">Liechtenstein</option>
+                                                        <option value="Lithuania">Lithuania</option>
+                                                        <option value="Luxembourg">Luxembourg</option>
+                                                        <option value="Macau">Macau</option>
+                                                        <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
+                                                        <option value="Madagascar">Madagascar</option>
+                                                        <option value="Malawi">Malawi</option>
+                                                        <option value="Malaysia">Malaysia</option>
+                                                        <option value="Maldives">Maldives</option>
+                                                        <option value="Mali">Mali</option>
+                                                        <option value="Malta">Malta</option>
+                                                        <option value="Marshall Islands">Marshall Islands</option>
+                                                        <option value="Martinique">Martinique</option>
+                                                        <option value="Mauritania">Mauritania</option>
+                                                        <option value="Mauritius">Mauritius</option>
+                                                        <option value="Mayotte">Mayotte</option>
+                                                        <option value="Mexico">Mexico</option>
+                                                        <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+                                                        <option value="Moldova, Republic of">Moldova, Republic of</option>
+                                                        <option value="Monaco">Monaco</option>
+                                                        <option value="Mongolia">Mongolia</option>
+                                                        <option value="Montserrat">Montserrat</option>
+                                                        <option value="Morocco">Morocco</option>
+                                                        <option value="Mozambique">Mozambique</option>
+                                                        <option value="Myanmar">Myanmar</option>
+                                                        <option value="Namibia">Namibia</option>
+                                                        <option value="Nauru">Nauru</option>
+                                                        <option value="Nepal">Nepal</option>
+                                                        <option value="Netherlands">Netherlands</option>
+                                                        <option value="Netherlands Antilles">Netherlands Antilles</option>
+                                                        <option value="New Caledonia">New Caledonia</option>
+                                                        <option value="New Zealand">New Zealand</option>
+                                                        <option value="Nicaragua">Nicaragua</option>
+                                                        <option value="Niger">Niger</option>
+                                                        <option value="Nigeria">Nigeria</option>
+                                                        <option value="Niue">Niue</option>
+                                                        <option value="Norfolk Island">Norfolk Island</option>
+                                                        <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+                                                        <option value="Norway">Norway</option>
+                                                        <option value="Oman">Oman</option>
+                                                        <option value="Pakistan">Pakistan</option>
+                                                        <option value="Palau">Palau</option>
+                                                        <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+                                                        <option value="Panama">Panama</option>
+                                                        <option value="Papua New Guinea">Papua New Guinea</option>
+                                                        <option value="Paraguay">Paraguay</option>
+                                                        <option value="Peru">Peru</option>
+                                                        <option value="Philippines">Philippines</option>
+                                                        <option value="Pitcairn">Pitcairn</option>
+                                                        <option value="Poland">Poland</option>
+                                                        <option value="Portugal">Portugal</option>
+                                                        <option value="Puerto Rico">Puerto Rico</option>
+                                                        <option value="Qatar">Qatar</option>
+                                                        <option value="Reunion">Reunion</option>
+                                                        <option value="Romania">Romania</option>
+                                                        <option value="Russian Federation">Russian Federation</option>
+                                                        <option value="Rwanda">Rwanda</option>
+                                                        <option value="Saint Helena">Saint Helena</option>
+                                                        <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+                                                        <option value="Saint Lucia">Saint Lucia</option>
+                                                        <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+                                                        <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
+                                                        <option value="Samoa">Samoa</option>
+                                                        <option value="San Marino">San Marino</option>
+                                                        <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+                                                        <option value="Saudi Arabia">Saudi Arabia</option>
+                                                        <option value="Senegal">Senegal</option>
+                                                        <option value="Seychelles">Seychelles</option>
+                                                        <option value="Sierra Leone">Sierra Leone</option>
+                                                        <option value="Singapore">Singapore</option>
+                                                        <option value="Slovakia">Slovakia</option>
+                                                        <option value="Slovenia">Slovenia</option>
+                                                        <option value="Solomon Islands">Solomon Islands</option>
+                                                        <option value="Somalia">Somalia</option>
+                                                        <option value="South Africa">South Africa</option>
+                                                        <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
+                                                        <option value="Spain">Spain</option>
+                                                        <option value="Sri Lanka">Sri Lanka</option>
+                                                        <option value="Sudan">Sudan</option>
+                                                        <option value="Suriname">Suriname</option>
+                                                        <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+                                                        <option value="Swaziland">Swaziland</option>
+                                                        <option value="Sweden">Sweden</option>
+                                                        <option value="Switzerland">Switzerland</option>
+                                                        <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+                                                        <option value="Taiwan">Taiwan</option>
+                                                        <option value="Tajikistan">Tajikistan</option>
+                                                        <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+                                                        <option value="Thailand">Thailand</option>
+                                                        <option value="Togo">Togo</option>
+                                                        <option value="Tokelau">Tokelau</option>
+                                                        <option value="Tonga">Tonga</option>
+                                                        <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+                                                        <option value="Tunisia">Tunisia</option>
+                                                        <option value="Turkey">Turkey</option>
+                                                        <option value="Turkmenistan">Turkmenistan</option>
+                                                        <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+                                                        <option value="Tuvalu">Tuvalu</option>
+                                                        <option value="Uganda">Uganda</option>
+                                                        <option value="Ukraine">Ukraine</option>
+                                                        <option value="United Arab Emirates">United Arab Emirates</option>
+                                                        <option value="United Kingdom">United Kingdom</option>
+                                                        <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+                                                        <option value="Uruguay">Uruguay</option>
+                                                        <option value="Uzbekistan">Uzbekistan</option>
+                                                        <option value="Vanuatu">Vanuatu</option>
+                                                        <option value="Venezuela">Venezuela</option>
+                                                        <option value="Viet Nam">Viet Nam</option>
+                                                        <option value="Virgin Islands, British">Virgin Islands, British</option>
+                                                        <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+                                                        <option value="Wallis and Futuna">Wallis and Futuna</option>
+                                                        <option value="Western Sahara">Western Sahara</option>
+                                                        <option value="Yemen">Yemen</option>
+                                                        <option value="Yugoslavia">Yugoslavia</option>
+                                                        <option value="Zambia">Zambia</option>
+                                                        <option value="Zimbabwe">Zimbabwe</option>
+                                                        <option value="Unknown">Unknown</option>
+                                                    </select>
+                                                </div>
+                                            </th:block>
+                                            <th:block th:if="${exceuter.isPersonEntity() == false}">
+                                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                    <label><span class="weight600">&#42;</span>Owner name</label>
+                                                    <input type="text" class="form-control rounded-borders ge-name" style="" th:value="${exceuter.entityName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                    <label>State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                                    <select class="form-control ge-state" name="State" th:attr="entity-index=${iter.index}" >
+                                                        <option th:value="${exceuter.organizationState}" th:text="${exceuter.organizationState}" th:attr="entity-id=${exceuter.id}"selected></option>
+                                                        <option value="">Select</option>
+                                                        <option value="Alabama">Alabama</option>
+                                                        <option value="Alaska">Alaska</option>
+                                                        <option value="Arizona">Arizona</option>
+                                                        <option value="Arkansas">Arkansas</option>
+                                                        <option value="California">California</option>
+                                                        <option value="Colorado">Colorado</option>
+                                                        <option value="Connecticut">Connecticut</option>
+                                                        <option value="Delaware">Delaware</option>
+                                                        <option value="District of Columbia">District of Columbia</option>
+                                                        <option value="Florida">Florida</option>
+                                                        <option value="Georgia">Georgia</option>
+                                                        <option value="Hawaii">Hawaii</option>
+                                                        <option value="Idaho">Idaho</option>
+                                                        <option value="Illinois">Illinois</option>
+                                                        <option value="Indiana">Indiana</option>
+                                                        <option value="Iowa">Iowa</option>
+                                                        <option value="Kansas">Kansas</option>
+                                                        <option value="Kentucky">Kentucky</option>
+                                                        <option value="Louisiana">Louisiana</option>
+                                                        <option value="Maine">Maine</option>
+                                                        <option value="Maryland">Maryland</option>
+                                                        <option value="Massachusetts">Massachusetts</option>
+                                                        <option value="Michigan">Michigan</option>
+                                                        <option value="Minnesota">Minnesota</option>
+                                                        <option value="Mississippi">Mississippi</option>
+                                                        <option value="Missouri">Missouri</option>
+                                                        <option value="Montana">Montana</option>
+                                                        <option value="Nebraska">Nebraska</option>
+                                                        <option value="Nevada">Nevada</option>
+                                                        <option value="New Hampshire">New Hampshire</option>
+                                                        <option value="New Jersey">New Jersey</option>
+                                                        <option value="New Mexico">New Mexico</option>
+                                                        <option value="New York">New York</option>
+                                                        <option value="North Carolina">North Carolina</option>
+                                                        <option value="North Dakota">North Dakota</option>
+                                                        <option value="Ohio">Ohio</option>
+                                                        <option value="Oklahoma">Oklahoma</option>
+                                                        <option value="Oregon">Oregon</option>
+                                                        <option value="Pennsylvania">Pennsylvania</option>
+                                                        <option value="Rhode Island">Rhode Island</option>
+                                                        <option value="South Carolina">South Carolina</option>
+                                                        <option value="South Dakota">South Dakota</option>
+                                                        <option value="Tennessee">Tennessee</option>
+                                                        <option value="Texas">Texas</option>
+                                                        <option value="Utah">Utah</option>
+                                                        <option value="Vermont">Vermont</option>
+                                                        <option value="Virginia">Virginia</option>
+                                                        <option value="Washington">Washington</option>
+                                                        <option value="West Virginia">West Virginia</option>
+                                                        <option value="Wisconsin">Wisconsin</option>
+                                                        <option value="Wyoming">Wyoming</option>
+                                                    </select>
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                    <label>Type</label>
+                                                    <span>
+                                                        <select  class="form-control ge-name-type" name="nameType"   style="" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                            <option th:value="${exceuter.getEntityAlternateNameType()}" th:text="${exceuter.getEntityAlternateNameType()}" selected>Select</option>
+                                                            <option value="">Select</option>
+                                                            <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
+                                                            <option value="Trading As(TA)">Trading As(TA)</option>
+                                                            <option value="Also Known As(AKA)">Also Known As(AKA)</option>
+                                                            <option value="Formerly">Formerly</option>
+                                                        </select>
+                                                    </span>
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-sm-6" style="">
+                                                    <label for="nameoftype">Name</label>
+                                                    <input type="text" class="form-control partner-alt-name"  name="nameoftype" th:value="${exceuter.getEntityAlternateName()}"   th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"><!--needs th:attribute-->
+                                                </div>
+                                            </th:block>
+                                        </div>  <!--end of partner row from server  -->
                                     </th:block>
-                                    <th:block th:if="${exceuter.isPersonEntity() == true}">
-                                        <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
-                                            <label><span class="weight600">&#42;</span>First name</label>
-                                            <input type="text" name="firstName" class="form-control ge-first-name" th:value="${exceuter.firstName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}" >
+                                </fieldset>
+                                <div class="col-xs-12 form-group form-group-md">
+                                    <div class="row addpartnership" style="display: none;">
+                                        <div class="form-group form-group-md col-xs-12 visuallyremoved resetpartner">
+                                            <button type="button" class="btn btn-sm close resetpartnerbtn" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
                                         </div>
-                                        <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
-                                            <label>Middle name</label>
-                                            <input type="text" name="middleName" class="form-control ge-middle-name" th:value="${exceuter.middleName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                        <div class="col-xs-12 form-group form-group-md">
+                                            <label>Select entity type</label>
+                                            <span>
+                                                <select id="domestic-entity-dropdown-partner" class="form-control" name="nameType">
+                                                    <option id="opt-none" value="none"></option>
+                                                    <option id="opt-domestic-ind" value="Individual">Individual</option>
+                                                    <option id="opt-domestic-soleP" value="Sole Proprietorship">Sole Proprietorship</option>
+                                                    <option id="opt-domestic-llc" value="Limited Liability Company">Limited Liability Company</option>
+                                                    <option id="opt-domestic-part" value="Partnership">Partnership</option>
+                                                    <option id="opt-domestic-jvc" value="Joint Venture">Joint Venture</option>
+                                                    <option id="opt-domestic-trt" value="Trust">Trust</option>
+                                                    <option id="opt-domestic-est" value="Estate">Estate</option>
+                                                </select>
+                                            </span>
                                         </div>
-                                        <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
-                                            <label><span class="weight600">&#42;</span>Last name</label>
-                                            <input type="text" name="lastName" class="form-control ge-last-name" th:value="${exceuter.lastName}"   th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                        <div class="col-xs-12">
+                                            <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity-new" style="display: none;">
+                                                <div class="row">
+                                                    <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
+                                                        <label><span class="weight600">&#42;</span>First name</label>
+                                                        <input type="text"   class="form-control ge-first-name"  required value="">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
+                                                        <label >Middle name</label>
+                                                        <input type="text" class="form-control ge-middle-name"  value="">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
+                                                        <label ><span class="weight600">&#42;</span>Last name</label>
+                                                        <input  type="text"  class="form-control ge-last-name"  required value="">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                        <label for="partner-suffix">Suffix</label>
+                                                        <input type="text" class="form-control" id="partner-suffix"   value="">
+
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                        <label>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
+                                                        <select class="form-control ge-citizenship">
+                                                            <option value="">Select</option>
+                                                            <option value="United States of America">United States of America</option>
+                                                            <option value="Afghanistan">Afghanistan</option>
+                                                            <option value="Albania">Albania</option>
+                                                            <option value="Algeria">Algeria</option>
+                                                            <option value="American Samoa">American Samoa</option>
+                                                            <option value="Andorra">Andorra</option>
+                                                            <option value="Angola">Angola</option>
+                                                            <option value="Anguilla">Anguilla</option>
+                                                            <option value="Antarctica">Antarctica</option>
+                                                            <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+                                                            <option value="Argentina">Argentina</option>
+                                                            <option value="Armenia">Armenia</option>
+                                                            <option value="Aruba">Aruba</option>
+                                                            <option value="Australia">Australia</option>
+                                                            <option value="Austria">Austria</option>
+                                                            <option value="Azerbaijan">Azerbaijan</option>
+                                                            <option value="Bahamas">Bahamas</option>
+                                                            <option value="Bahrain">Bahrain</option>
+                                                            <option value="Bangladesh">Bangladesh</option>
+                                                            <option value="Barbados">Barbados</option>
+                                                            <option value="Belarus">Belarus</option>
+                                                            <option value="Belgium">Belgium</option>
+                                                            <option value="Belize">Belize</option>
+                                                            <option value="Benin">Benin</option>
+                                                            <option value="Bermuda">Bermuda</option>
+                                                            <option value="Bhutan">Bhutan</option>
+                                                            <option value="Bolivia">Bolivia</option>
+                                                            <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+                                                            <option value="Botswana">Botswana</option>
+                                                            <option value="Bouvet Island">Bouvet Island</option>
+                                                            <option value="Brazil">Brazil</option>
+                                                            <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+                                                            <option value="Brunei Darussalam">Brunei Darussalam</option>
+                                                            <option value="Bulgaria">Bulgaria</option>
+                                                            <option value="Burkina Faso">Burkina Faso</option>
+                                                            <option value="Burundi">Burundi</option>
+                                                            <option value="Canada">Canada</option>
+                                                            <option value="Cambodia">Cambodia</option>
+                                                            <option value="Cameroon">Cameroon</option>
+                                                            <option value="Cape Verde">Cape Verde</option>
+                                                            <option value="Cayman Islands">Cayman Islands</option>
+                                                            <option value="Central African Republic">Central African Republic</option>
+                                                            <option value="Chad">Chad</option>
+                                                            <option value="Chile">Chile</option>
+                                                            <option value="China">China</option>
+                                                            <option value="Christmas Island">Christmas Island</option>
+                                                            <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+                                                            <option value="Colombia">Colombia</option>
+                                                            <option value="Comoros">Comoros</option>
+                                                            <option value="Congo">Congo</option>
+                                                            <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
+                                                            <option value="Cook Islands">Cook Islands</option>
+                                                            <option value="Costa Rica">Costa Rica</option>
+                                                            <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
+                                                            <option value="Croatia">Croatia</option>
+                                                            <option value="Cuba">Cuba</option>
+                                                            <option value="Cyprus">Cyprus</option>
+                                                            <option value="Czech Republic">Czech Republic</option>
+                                                            <option value="Denmark">Denmark</option>
+                                                            <option value="Djibouti">Djibouti</option>
+                                                            <option value="Dominica">Dominica</option>
+                                                            <option value="Dominican Republic">Dominican Republic</option>
+                                                            <option value="East Timor">East Timor</option>
+                                                            <option value="Ecuador">Ecuador</option>
+                                                            <option value="Egypt">Egypt</option>
+                                                            <option value="El Salvador">El Salvador</option>
+                                                            <option value="Equatorial Guinea">Equatorial Guinea</option>
+                                                            <option value="Eritrea">Eritrea</option>
+                                                            <option value="Estonia">Estonia</option>
+                                                            <option value="Ethiopia">Ethiopia</option>
+                                                            <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+                                                            <option value="Faroe Islands">Faroe Islands</option>
+                                                            <option value="Fiji">Fiji</option>
+                                                            <option value="Finland">Finland</option>
+                                                            <option value="France">France</option>
+                                                            <option value="French Guiana">French Guiana</option>
+                                                            <option value="French Polynesia">French Polynesia</option>
+                                                            <option value="French Southern Territories">French Southern Territories</option>
+                                                            <option value="Gabon">Gabon</option>
+                                                            <option value="Gambia">Gambia</option>
+                                                            <option value="Georgia">Georgia</option>
+                                                            <option value="Germany">Germany</option>
+                                                            <option value="Ghana">Ghana</option>
+                                                            <option value="Gibraltar">Gibraltar</option>
+                                                            <option value="Greece">Greece</option>
+                                                            <option value="Greenland">Greenland</option>
+                                                            <option value="Grenada">Grenada</option>
+                                                            <option value="Guadeloupe">Guadeloupe</option>
+                                                            <option value="Guam">Guam</option>
+                                                            <option value="Guatemala">Guatemala</option>
+                                                            <option value="Guinea">Guinea</option>
+                                                            <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
+                                                            <option value="Guyana">Guyana</option>
+                                                            <option value="Haiti">Haiti</option>
+                                                            <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+                                                            <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+                                                            <option value="Honduras">Honduras</option>
+                                                            <option value="Hong Kong">Hong Kong</option>
+                                                            <option value="Hungary">Hungary</option>
+                                                            <option value="Iceland">Iceland</option>
+                                                            <option value="India">India</option>
+                                                            <option value="Indonesia">Indonesia</option>
+                                                            <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+                                                            <option value="Iraq">Iraq</option>
+                                                            <option value="Ireland">Ireland</option>
+                                                            <option value="Israel">Israel</option>
+                                                            <option value="Italy">Italy</option>
+                                                            <option value="Jamaica">Jamaica</option>
+                                                            <option value="Japan">Japan</option>
+                                                            <option value="Jordan">Jordan</option>
+                                                            <option value="Kazakstan">Kazakstan</option>
+                                                            <option value="Kenya">Kenya</option>
+                                                            <option value="Kiribati">Kiribati</option>
+                                                            <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
+                                                            <option value="Korea, Republic of">Korea, Republic of</option>
+                                                            <option value="Kuwait">Kuwait</option>
+                                                            <option value="Kyrgyzstan">Kyrgyzstan</option>
+                                                            <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
+                                                            <option value="Latvia">Latvia</option>
+                                                            <option value="Lebanon">Lebanon</option>
+                                                            <option value="Lesotho">Lesotho</option>
+                                                            <option value="Liberia">Liberia</option>
+                                                            <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
+                                                            <option value="Liechtenstein">Liechtenstein</option>
+                                                            <option value="Lithuania">Lithuania</option>
+                                                            <option value="Luxembourg">Luxembourg</option>
+                                                            <option value="Macau">Macau</option>
+                                                            <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
+                                                            <option value="Madagascar">Madagascar</option>
+                                                            <option value="Malawi">Malawi</option>
+                                                            <option value="Malaysia">Malaysia</option>
+                                                            <option value="Maldives">Maldives</option>
+                                                            <option value="Mali">Mali</option>
+                                                            <option value="Malta">Malta</option>
+                                                            <option value="Marshall Islands">Marshall Islands</option>
+                                                            <option value="Martinique">Martinique</option>
+                                                            <option value="Mauritania">Mauritania</option>
+                                                            <option value="Mauritius">Mauritius</option>
+                                                            <option value="Mayotte">Mayotte</option>
+                                                            <option value="Mexico">Mexico</option>
+                                                            <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+                                                            <option value="Moldova, Republic of">Moldova, Republic of</option>
+                                                            <option value="Monaco">Monaco</option>
+                                                            <option value="Mongolia">Mongolia</option>
+                                                            <option value="Montserrat">Montserrat</option>
+                                                            <option value="Morocco">Morocco</option>
+                                                            <option value="Mozambique">Mozambique</option>
+                                                            <option value="Myanmar">Myanmar</option>
+                                                            <option value="Namibia">Namibia</option>
+                                                            <option value="Nauru">Nauru</option>
+                                                            <option value="Nepal">Nepal</option>
+                                                            <option value="Netherlands">Netherlands</option>
+                                                            <option value="Netherlands Antilles">Netherlands Antilles</option>
+                                                            <option value="New Caledonia">New Caledonia</option>
+                                                            <option value="New Zealand">New Zealand</option>
+                                                            <option value="Nicaragua">Nicaragua</option>
+                                                            <option value="Niger">Niger</option>
+                                                            <option value="Nigeria">Nigeria</option>
+                                                            <option value="Niue">Niue</option>
+                                                            <option value="Norfolk Island">Norfolk Island</option>
+                                                            <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+                                                            <option value="Norway">Norway</option>
+                                                            <option value="Oman">Oman</option>
+                                                            <option value="Pakistan">Pakistan</option>
+                                                            <option value="Palau">Palau</option>
+                                                            <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+                                                            <option value="Panama">Panama</option>
+                                                            <option value="Papua New Guinea">Papua New Guinea</option>
+                                                            <option value="Paraguay">Paraguay</option>
+                                                            <option value="Peru">Peru</option>
+                                                            <option value="Philippines">Philippines</option>
+                                                            <option value="Pitcairn">Pitcairn</option>
+                                                            <option value="Poland">Poland</option>
+                                                            <option value="Portugal">Portugal</option>
+                                                            <option value="Puerto Rico">Puerto Rico</option>
+                                                            <option value="Qatar">Qatar</option>
+                                                            <option value="Reunion">Reunion</option>
+                                                            <option value="Romania">Romania</option>
+                                                            <option value="Russian Federation">Russian Federation</option>
+                                                            <option value="Rwanda">Rwanda</option>
+                                                            <option value="Saint Helena">Saint Helena</option>
+                                                            <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+                                                            <option value="Saint Lucia">Saint Lucia</option>
+                                                            <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+                                                            <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
+                                                            <option value="Samoa">Samoa</option>
+                                                            <option value="San Marino">San Marino</option>
+                                                            <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+                                                            <option value="Saudi Arabia">Saudi Arabia</option>
+                                                            <option value="Senegal">Senegal</option>
+                                                            <option value="Seychelles">Seychelles</option>
+                                                            <option value="Sierra Leone">Sierra Leone</option>
+                                                            <option value="Singapore">Singapore</option>
+                                                            <option value="Slovakia">Slovakia</option>
+                                                            <option value="Slovenia">Slovenia</option>
+                                                            <option value="Solomon Islands">Solomon Islands</option>
+                                                            <option value="Somalia">Somalia</option>
+                                                            <option value="South Africa">South Africa</option>
+                                                            <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
+                                                            <option value="Spain">Spain</option>
+                                                            <option value="Sri Lanka">Sri Lanka</option>
+                                                            <option value="Sudan">Sudan</option>
+                                                            <option value="Suriname">Suriname</option>
+                                                            <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+                                                            <option value="Swaziland">Swaziland</option>
+                                                            <option value="Sweden">Sweden</option>
+                                                            <option value="Switzerland">Switzerland</option>
+                                                            <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+                                                            <option value="Taiwan">Taiwan</option>
+                                                            <option value="Tajikistan">Tajikistan</option>
+                                                            <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+                                                            <option value="Thailand">Thailand</option>
+                                                            <option value="Togo">Togo</option>
+                                                            <option value="Tokelau">Tokelau</option>
+                                                            <option value="Tonga">Tonga</option>
+                                                            <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+                                                            <option value="Tunisia">Tunisia</option>
+                                                            <option value="Turkey">Turkey</option>
+                                                            <option value="Turkmenistan">Turkmenistan</option>
+                                                            <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+                                                            <option value="Tuvalu">Tuvalu</option>
+                                                            <option value="Uganda">Uganda</option>
+                                                            <option value="Ukraine">Ukraine</option>
+                                                            <option value="United Arab Emirates">United Arab Emirates</option>
+                                                            <option value="United Kingdom">United Kingdom</option>
+                                                            <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+                                                            <option value="Uruguay">Uruguay</option>
+                                                            <option value="Uzbekistan">Uzbekistan</option>
+                                                            <option value="Vanuatu">Vanuatu</option>
+                                                            <option value="Venezuela">Venezuela</option>
+                                                            <option value="Viet Nam">Viet Nam</option>
+                                                            <option value="Virgin Islands, British">Virgin Islands, British</option>
+                                                            <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+                                                            <option value="Wallis and Futuna">Wallis and Futuna</option>
+                                                            <option value="Western Sahara">Western Sahara</option>
+                                                            <option value="Yemen">Yemen</option>
+                                                            <option value="Yugoslavia">Yugoslavia</option>
+                                                            <option value="Zambia">Zambia</option>
+                                                            <option value="Zimbabwe">Zimbabwe</option>
+                                                            <option value="Unknown">Unknown</option>
+                                                        </select>
+                                                    </div>
+                                                </div>
+                                            </fieldset>
+                                            <fieldset aria-labelledby="proprietorinfo" id="none-individual-partner-entity-new" style="display: none;">
+                                                <div class="row">
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                        <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
+                                                        <input type="text" class="form-control rounded-borders ge-name"  required  value="">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-9">
+                                                        <label>State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                                        <select  class="form-control ge-state">
+                                                            <option value="">Select</option>
+                                                            <option value="Alabama">Alabama</option>
+                                                            <option value="Alaska">Alaska</option>
+                                                            <option value="Arizona">Arizona</option>
+                                                            <option value="Arkansas">Arkansas</option>
+                                                            <option value="California">California</option>
+                                                            <option value="Colorado">Colorado</option>
+                                                            <option value="Connecticut">Connecticut</option>
+                                                            <option value="Delaware">Delaware</option>
+                                                            <option value="District of Columbia">District of Columbia</option>
+                                                            <option value="Florida">Florida</option>
+                                                            <option value="Georgia">Georgia</option>
+                                                            <option value="Hawaii">Hawaii</option>
+                                                            <option value="Idaho">Idaho</option>
+                                                            <option value="Illinois">Illinois</option>
+                                                            <option value="Indiana">Indiana</option>
+                                                            <option value="Iowa">Iowa</option>
+                                                            <option value="Kansas">Kansas</option>
+                                                            <option value="Kentucky">Kentucky</option>
+                                                            <option value="Louisiana">Louisiana</option>
+                                                            <option value="Maine">Maine</option>
+                                                            <option value="Maryland">Maryland</option>
+                                                            <option value="Massachusetts">Massachusetts</option>
+                                                            <option value="Michigan">Michigan</option>
+                                                            <option value="Minnesota">Minnesota</option>
+                                                            <option value="Mississippi">Mississippi</option>
+                                                            <option value="Missouri">Missouri</option>
+                                                            <option value="Montana">Montana</option>
+                                                            <option value="Nebraska">Nebraska</option>
+                                                            <option value="Nevada">Nevada</option>
+                                                            <option value="New Hampshire">New Hampshire</option>
+                                                            <option value="New Jersey">New Jersey</option>
+                                                            <option value="New Mexico">New Mexico</option>
+                                                            <option value="New York">New York</option>
+                                                            <option value="North Carolina">North Carolina</option>
+                                                            <option value="North Dakota">North Dakota</option>
+                                                            <option value="Ohio">Ohio</option>
+                                                            <option value="Oklahoma">Oklahoma</option>
+                                                            <option value="Oregon">Oregon</option>
+                                                            <option value="Pennsylvania">Pennsylvania</option>
+                                                            <option value="Rhode Island">Rhode Island</option>
+                                                            <option value="South Carolina">South Carolina</option>
+                                                            <option value="South Dakota">South Dakota</option>
+                                                            <option value="Tennessee">Tennessee</option>
+                                                            <option value="Texas">Texas</option>
+                                                            <option value="Utah">Utah</option>
+                                                            <option value="Vermont">Vermont</option>
+                                                            <option value="Virginia">Virginia</option>
+                                                            <option value="Washington">Washington</option>
+                                                            <option value="West Virginia">West Virginia</option>
+                                                            <option value="Wisconsin">Wisconsin</option>
+                                                            <option value="Wyoming">Wyoming</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-md-6">
+                                                        <label>Type</label>
+                                                        <span>
+                                                            <select class="form-control ge-name-type" >
+                                                                <option value="">Select</option>
+                                                                <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
+                                                                <option value="Trading As(TA)">Trading As(TA)</option>
+                                                                <option value="Also Known As(AKA)">Also Known As(AKA)</option>
+                                                                <option value="Formerly">Formerly</option>
+                                                            </select>
+                                                    </span>
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-md-6" style="">
+                                                        <label for="nameoftype">Name</label>
+                                                        <input type="text" class="form-control partner-alt-name"  name="nameoftype" ><!--needs th:attribute-->
+                                                    </div>
+                                                </div>
+                                            </fieldset>
+                                        </div> <!-- end of arrary dto object -->
+                                    </div>
+                                </div>
+                                <!--END hidden content-->
+                                <div class="appendpartner col-xs-12"></div>
+                                <div class="row" id="hideshow_addpartner">
+
+                                    <div class="col-xs-12 form-group form-group-md" aria-label="add a partner">
+                                        <div class="inlinebuttons btn-group btn-group-justified">
+                                            <div class="btn-group col-xs-6">
+                                                <button type="button" class="btn btn-sm btn-success addinitial" id="addpartner">Add Partner</button>
+                                            </div>
                                         </div>
-                                        <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
-                                            <label>Suffix</label>
-                                            <input type="text" class="form-control ge-suffix" name="suffix" />
-                                        </div>
-                                        <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
-                                            <label> <span class="weight600">&#42;</span>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
-                                            <select class="form-control ge-citizenship" name="owner-citizenship" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
-                                                <option th:value="${exceuter.entityCitizenship}" th:text="${exceuter.entityCitizenship}" selected  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"></option>
+                                    </div><!--// add button-->
+                                </div><!--// hide / show add partner-->
+                                <!--END Sole Proprietor Information Form-->
+                                <!--START Owner Address Information Form-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="addressinfo">Owner Address Information</h2>
+                                </div>
+                                <fieldset aria-labelledby="addressinfo">
+                                    <div class="row">
+                                        <div class="form-group form-group-md col-md-12 col-lg-7">
+                                            <label for="OwnerAddressCountry"><span class="weight600">&#42;</span>Country / U.S. territory</label>
+                                            <select class="form-control" id="OwnerAddressCountry" name="territory" th:field="${owner.country}" >
                                                 <option value="">Select</option>
                                                 <option value="United States of America">United States of America</option>
                                                 <option value="Afghanistan">Afghanistan</option>
@@ -458,16 +1181,25 @@
                                                 <option value="Unknown">Unknown</option>
                                             </select>
                                         </div>
-                                    </th:block>
-                                    <th:block th:if="${exceuter.isPersonEntity() == false}">
-                                        <div class="form-group form-group-md col-xs-6">
-                                            <label><span class="weight600">&#42;</span>Owner name</label>
-                                            <input type="text" class="form-control rounded-borders ge-name" style="" th:value="${exceuter.entityName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                        <div class="form-group form-group-md col-md-12 col-lg-9">
+                                            <label for="ownerAddress1"><span class="weight600">&#42;</span>Address line 1</label>
+                                            <input type="text" class="form-control" id="ownerAddress1" th:value="${owner.address1}" >
                                         </div>
-                                        <div class="form-group form-group-md col-xs-12 col-sm-9">
-                                            <label><span class="weight600">&#42;</span>State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
-                                            <select class="form-control ge-state" name="State" th:attr="entity-index=${iter.index}" >
-                                                <option th:value="${exceuter.organizationState}" th:text="${exceuter.organizationState}" th:attr="entity-id=${exceuter.id}"selected></option>
+                                        <div class="form-group form-group-md col-md-12 col-lg-9">
+                                            <label for="addressline2">Address line 2</label>
+                                            <input type="text" class="form-control" id="addressline2" >
+                                        </div>
+                                        <div class="form-group form-group-md col-md-12 col-lg-9">
+                                            <label for="addressline3">Address line 3</label>
+                                            <input type="text" class="form-control" id="addressline3" >
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                            <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
+                                            <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}">
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                            <label for="ownerState"><span class="weight600">&#42;</span>State/Province/Territory</label>
+                                            <select class="form-control" id="ownerState" th:field="${owner.state}" required>
                                                 <option value="">Select</option>
                                                 <option value="Alabama">Alabama</option>
                                                 <option value="Alaska">Alaska</option>
@@ -521,801 +1253,71 @@
                                                 <option value="Wisconsin">Wisconsin</option>
                                                 <option value="Wyoming">Wyoming</option>
                                             </select>
-                                        </div>
-                                        <div class="form-group form-group-md col-xs-6">
-                                            <label>Type</label>
-                                            <span>
-                                                <select  class="form-control ge-name-type" name="nameType"   style="" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
-                                                    <option th:value="${exceuter.getEntityAlternateNameType()}" th:text="${exceuter.getEntityAlternateNameType()}" selected>Select</option>
-                                                    <option value="">Select</option>
-                                                    <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
-                                                    <option value="Trading As(TA)">Trading As(TA)</option>
-                                                    <option value="Also Known As(AKA)">Also Known As(AKA)</option>
-                                                    <option value="Formerly">Formerly</option>
-                                                </select>
-                                            </span>
-                                        </div>
-                                        <div class="form-group form-group-md col-xs-6" style="">
-                                            <label for="nameoftype">Name</label>
-                                            <input type="text" class="form-control partner-alt-name"  name="nameoftype" th:value="${exceuter.getEntityAlternateName()}"   th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"><!--needs th:attribute-->
-                                        </div>
-                                    </th:block>
-                                </div>  <!--end of partner row from server  -->
-                            </th:block>
-                        </fieldset>
-                        <div class="col-xs-12 form-group form-group-md">
-                            <div class="row addpartnership" style="display: none;">
-                                <div class="form-group form-group-md col-xs-12 visuallyremoved resetpartner">
-                                    <button type="button" class="btn btn-sm close resetpartnerbtn" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
-                                </div>
-                                <div class="col-xs-12 form-group form-group-md">
-                                    <label>Select entity type</label>
-                                    <span>
-                                        <select id="domestic-entity-dropdown-partner" class="form-control" name="nameType">
-                                            <option id="opt-none" value="none"></option>
-                                            <option id="opt-domestic-ind" value="Individual">Individual</option>
-                                            <option id="opt-domestic-soleP" value="Sole Proprietorship">Sole Proprietorship</option>
-                                            <option id="opt-domestic-llc" value="Limited Liability Company">Limited Liability Company</option>
-                                            <option id="opt-domestic-part" value="Partnership">Partnership</option>
-                                            <option id="opt-domestic-jvc" value="Joint Venture">Joint Venture</option>
-                                            <option id="opt-domestic-trt" value="Trust">Trust</option>
-                                            <option id="opt-domestic-est" value="Estate">Estate</option>
-                                        </select>
-                                    </span>
-                                </div>
-                                <div class="col-xs-12">
-                                    <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity-new" style="display: none;">
-                                        <div class="row">
-                                            <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
-                                                <label><span class="weight600">&#42;</span>First name</label>
-                                                <input type="text"   class="form-control ge-first-name"  required value="">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
-                                                <label >Middle name</label>
-                                                <input type="text" class="form-control ge-middle-name"  value="">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
-                                                <label ><span class="weight600">&#42;</span>Last name</label>
-                                                <input  type="text"  class="form-control ge-last-name"  required value="">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                                <label for="partner-suffix">Suffix</label>
-                                                <input type="text" class="form-control" id="partner-suffix"   value="">
 
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                                <label ><span class="weight600">&#42;</span>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
-                                                <select class="form-control ge-citizenship"  required="">
-                                                    <option value="">Select</option>
-                                                    <option value="United States of America">United States of America</option>
-                                                    <option value="Afghanistan">Afghanistan</option>
-                                                    <option value="Albania">Albania</option>
-                                                    <option value="Algeria">Algeria</option>
-                                                    <option value="American Samoa">American Samoa</option>
-                                                    <option value="Andorra">Andorra</option>
-                                                    <option value="Angola">Angola</option>
-                                                    <option value="Anguilla">Anguilla</option>
-                                                    <option value="Antarctica">Antarctica</option>
-                                                    <option value="Antigua and Barbuda">Antigua and Barbuda</option>
-                                                    <option value="Argentina">Argentina</option>
-                                                    <option value="Armenia">Armenia</option>
-                                                    <option value="Aruba">Aruba</option>
-                                                    <option value="Australia">Australia</option>
-                                                    <option value="Austria">Austria</option>
-                                                    <option value="Azerbaijan">Azerbaijan</option>
-                                                    <option value="Bahamas">Bahamas</option>
-                                                    <option value="Bahrain">Bahrain</option>
-                                                    <option value="Bangladesh">Bangladesh</option>
-                                                    <option value="Barbados">Barbados</option>
-                                                    <option value="Belarus">Belarus</option>
-                                                    <option value="Belgium">Belgium</option>
-                                                    <option value="Belize">Belize</option>
-                                                    <option value="Benin">Benin</option>
-                                                    <option value="Bermuda">Bermuda</option>
-                                                    <option value="Bhutan">Bhutan</option>
-                                                    <option value="Bolivia">Bolivia</option>
-                                                    <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
-                                                    <option value="Botswana">Botswana</option>
-                                                    <option value="Bouvet Island">Bouvet Island</option>
-                                                    <option value="Brazil">Brazil</option>
-                                                    <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
-                                                    <option value="Brunei Darussalam">Brunei Darussalam</option>
-                                                    <option value="Bulgaria">Bulgaria</option>
-                                                    <option value="Burkina Faso">Burkina Faso</option>
-                                                    <option value="Burundi">Burundi</option>
-                                                    <option value="Canada">Canada</option>
-                                                    <option value="Cambodia">Cambodia</option>
-                                                    <option value="Cameroon">Cameroon</option>
-                                                    <option value="Cape Verde">Cape Verde</option>
-                                                    <option value="Cayman Islands">Cayman Islands</option>
-                                                    <option value="Central African Republic">Central African Republic</option>
-                                                    <option value="Chad">Chad</option>
-                                                    <option value="Chile">Chile</option>
-                                                    <option value="China">China</option>
-                                                    <option value="Christmas Island">Christmas Island</option>
-                                                    <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
-                                                    <option value="Colombia">Colombia</option>
-                                                    <option value="Comoros">Comoros</option>
-                                                    <option value="Congo">Congo</option>
-                                                    <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
-                                                    <option value="Cook Islands">Cook Islands</option>
-                                                    <option value="Costa Rica">Costa Rica</option>
-                                                    <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
-                                                    <option value="Croatia">Croatia</option>
-                                                    <option value="Cuba">Cuba</option>
-                                                    <option value="Cyprus">Cyprus</option>
-                                                    <option value="Czech Republic">Czech Republic</option>
-                                                    <option value="Denmark">Denmark</option>
-                                                    <option value="Djibouti">Djibouti</option>
-                                                    <option value="Dominica">Dominica</option>
-                                                    <option value="Dominican Republic">Dominican Republic</option>
-                                                    <option value="East Timor">East Timor</option>
-                                                    <option value="Ecuador">Ecuador</option>
-                                                    <option value="Egypt">Egypt</option>
-                                                    <option value="El Salvador">El Salvador</option>
-                                                    <option value="Equatorial Guinea">Equatorial Guinea</option>
-                                                    <option value="Eritrea">Eritrea</option>
-                                                    <option value="Estonia">Estonia</option>
-                                                    <option value="Ethiopia">Ethiopia</option>
-                                                    <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
-                                                    <option value="Faroe Islands">Faroe Islands</option>
-                                                    <option value="Fiji">Fiji</option>
-                                                    <option value="Finland">Finland</option>
-                                                    <option value="France">France</option>
-                                                    <option value="French Guiana">French Guiana</option>
-                                                    <option value="French Polynesia">French Polynesia</option>
-                                                    <option value="French Southern Territories">French Southern Territories</option>
-                                                    <option value="Gabon">Gabon</option>
-                                                    <option value="Gambia">Gambia</option>
-                                                    <option value="Georgia">Georgia</option>
-                                                    <option value="Germany">Germany</option>
-                                                    <option value="Ghana">Ghana</option>
-                                                    <option value="Gibraltar">Gibraltar</option>
-                                                    <option value="Greece">Greece</option>
-                                                    <option value="Greenland">Greenland</option>
-                                                    <option value="Grenada">Grenada</option>
-                                                    <option value="Guadeloupe">Guadeloupe</option>
-                                                    <option value="Guam">Guam</option>
-                                                    <option value="Guatemala">Guatemala</option>
-                                                    <option value="Guinea">Guinea</option>
-                                                    <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
-                                                    <option value="Guyana">Guyana</option>
-                                                    <option value="Haiti">Haiti</option>
-                                                    <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
-                                                    <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
-                                                    <option value="Honduras">Honduras</option>
-                                                    <option value="Hong Kong">Hong Kong</option>
-                                                    <option value="Hungary">Hungary</option>
-                                                    <option value="Iceland">Iceland</option>
-                                                    <option value="India">India</option>
-                                                    <option value="Indonesia">Indonesia</option>
-                                                    <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
-                                                    <option value="Iraq">Iraq</option>
-                                                    <option value="Ireland">Ireland</option>
-                                                    <option value="Israel">Israel</option>
-                                                    <option value="Italy">Italy</option>
-                                                    <option value="Jamaica">Jamaica</option>
-                                                    <option value="Japan">Japan</option>
-                                                    <option value="Jordan">Jordan</option>
-                                                    <option value="Kazakstan">Kazakstan</option>
-                                                    <option value="Kenya">Kenya</option>
-                                                    <option value="Kiribati">Kiribati</option>
-                                                    <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
-                                                    <option value="Korea, Republic of">Korea, Republic of</option>
-                                                    <option value="Kuwait">Kuwait</option>
-                                                    <option value="Kyrgyzstan">Kyrgyzstan</option>
-                                                    <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
-                                                    <option value="Latvia">Latvia</option>
-                                                    <option value="Lebanon">Lebanon</option>
-                                                    <option value="Lesotho">Lesotho</option>
-                                                    <option value="Liberia">Liberia</option>
-                                                    <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
-                                                    <option value="Liechtenstein">Liechtenstein</option>
-                                                    <option value="Lithuania">Lithuania</option>
-                                                    <option value="Luxembourg">Luxembourg</option>
-                                                    <option value="Macau">Macau</option>
-                                                    <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
-                                                    <option value="Madagascar">Madagascar</option>
-                                                    <option value="Malawi">Malawi</option>
-                                                    <option value="Malaysia">Malaysia</option>
-                                                    <option value="Maldives">Maldives</option>
-                                                    <option value="Mali">Mali</option>
-                                                    <option value="Malta">Malta</option>
-                                                    <option value="Marshall Islands">Marshall Islands</option>
-                                                    <option value="Martinique">Martinique</option>
-                                                    <option value="Mauritania">Mauritania</option>
-                                                    <option value="Mauritius">Mauritius</option>
-                                                    <option value="Mayotte">Mayotte</option>
-                                                    <option value="Mexico">Mexico</option>
-                                                    <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
-                                                    <option value="Moldova, Republic of">Moldova, Republic of</option>
-                                                    <option value="Monaco">Monaco</option>
-                                                    <option value="Mongolia">Mongolia</option>
-                                                    <option value="Montserrat">Montserrat</option>
-                                                    <option value="Morocco">Morocco</option>
-                                                    <option value="Mozambique">Mozambique</option>
-                                                    <option value="Myanmar">Myanmar</option>
-                                                    <option value="Namibia">Namibia</option>
-                                                    <option value="Nauru">Nauru</option>
-                                                    <option value="Nepal">Nepal</option>
-                                                    <option value="Netherlands">Netherlands</option>
-                                                    <option value="Netherlands Antilles">Netherlands Antilles</option>
-                                                    <option value="New Caledonia">New Caledonia</option>
-                                                    <option value="New Zealand">New Zealand</option>
-                                                    <option value="Nicaragua">Nicaragua</option>
-                                                    <option value="Niger">Niger</option>
-                                                    <option value="Nigeria">Nigeria</option>
-                                                    <option value="Niue">Niue</option>
-                                                    <option value="Norfolk Island">Norfolk Island</option>
-                                                    <option value="Northern Mariana Islands">Northern Mariana Islands</option>
-                                                    <option value="Norway">Norway</option>
-                                                    <option value="Oman">Oman</option>
-                                                    <option value="Pakistan">Pakistan</option>
-                                                    <option value="Palau">Palau</option>
-                                                    <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
-                                                    <option value="Panama">Panama</option>
-                                                    <option value="Papua New Guinea">Papua New Guinea</option>
-                                                    <option value="Paraguay">Paraguay</option>
-                                                    <option value="Peru">Peru</option>
-                                                    <option value="Philippines">Philippines</option>
-                                                    <option value="Pitcairn">Pitcairn</option>
-                                                    <option value="Poland">Poland</option>
-                                                    <option value="Portugal">Portugal</option>
-                                                    <option value="Puerto Rico">Puerto Rico</option>
-                                                    <option value="Qatar">Qatar</option>
-                                                    <option value="Reunion">Reunion</option>
-                                                    <option value="Romania">Romania</option>
-                                                    <option value="Russian Federation">Russian Federation</option>
-                                                    <option value="Rwanda">Rwanda</option>
-                                                    <option value="Saint Helena">Saint Helena</option>
-                                                    <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
-                                                    <option value="Saint Lucia">Saint Lucia</option>
-                                                    <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
-                                                    <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
-                                                    <option value="Samoa">Samoa</option>
-                                                    <option value="San Marino">San Marino</option>
-                                                    <option value="Sao Tome and Principe">Sao Tome and Principe</option>
-                                                    <option value="Saudi Arabia">Saudi Arabia</option>
-                                                    <option value="Senegal">Senegal</option>
-                                                    <option value="Seychelles">Seychelles</option>
-                                                    <option value="Sierra Leone">Sierra Leone</option>
-                                                    <option value="Singapore">Singapore</option>
-                                                    <option value="Slovakia">Slovakia</option>
-                                                    <option value="Slovenia">Slovenia</option>
-                                                    <option value="Solomon Islands">Solomon Islands</option>
-                                                    <option value="Somalia">Somalia</option>
-                                                    <option value="South Africa">South Africa</option>
-                                                    <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
-                                                    <option value="Spain">Spain</option>
-                                                    <option value="Sri Lanka">Sri Lanka</option>
-                                                    <option value="Sudan">Sudan</option>
-                                                    <option value="Suriname">Suriname</option>
-                                                    <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
-                                                    <option value="Swaziland">Swaziland</option>
-                                                    <option value="Sweden">Sweden</option>
-                                                    <option value="Switzerland">Switzerland</option>
-                                                    <option value="Syrian Arab Republic">Syrian Arab Republic</option>
-                                                    <option value="Taiwan">Taiwan</option>
-                                                    <option value="Tajikistan">Tajikistan</option>
-                                                    <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
-                                                    <option value="Thailand">Thailand</option>
-                                                    <option value="Togo">Togo</option>
-                                                    <option value="Tokelau">Tokelau</option>
-                                                    <option value="Tonga">Tonga</option>
-                                                    <option value="Trinidad and Tobago">Trinidad and Tobago</option>
-                                                    <option value="Tunisia">Tunisia</option>
-                                                    <option value="Turkey">Turkey</option>
-                                                    <option value="Turkmenistan">Turkmenistan</option>
-                                                    <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
-                                                    <option value="Tuvalu">Tuvalu</option>
-                                                    <option value="Uganda">Uganda</option>
-                                                    <option value="Ukraine">Ukraine</option>
-                                                    <option value="United Arab Emirates">United Arab Emirates</option>
-                                                    <option value="United Kingdom">United Kingdom</option>
-                                                    <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
-                                                    <option value="Uruguay">Uruguay</option>
-                                                    <option value="Uzbekistan">Uzbekistan</option>
-                                                    <option value="Vanuatu">Vanuatu</option>
-                                                    <option value="Venezuela">Venezuela</option>
-                                                    <option value="Viet Nam">Viet Nam</option>
-                                                    <option value="Virgin Islands, British">Virgin Islands, British</option>
-                                                    <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
-                                                    <option value="Wallis and Futuna">Wallis and Futuna</option>
-                                                    <option value="Western Sahara">Western Sahara</option>
-                                                    <option value="Yemen">Yemen</option>
-                                                    <option value="Yugoslavia">Yugoslavia</option>
-                                                    <option value="Zambia">Zambia</option>
-                                                    <option value="Zimbabwe">Zimbabwe</option>
-                                                    <option value="Unknown">Unknown</option>
-                                                </select>
-                                            </div>
                                         </div>
-                                    </fieldset>
-                                    <fieldset aria-labelledby="proprietorinfo" id="none-individual-partner-entity-new" style="display: none;">
+                                        <div class="form-group form-group-md col-xs-12 col-sm-5">
+                                            <label for="ownerZipcode"><span class="weight600">&#42;</span>Zip code/Postal code</label>
+                                            <input type="text" class="form-control" id="ownerZipcode" placeholder=""  th:value="${owner.zipcode}">
+                                        </div>
+                                    </div>
+                                </fieldset>
+                                <!--END Owner Address Information Form-->
+                                <!--START Additional Information Form-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="additionalinfo">Additional Information</h2>
+                                </div>
+                                <fieldset aria-labelledby="additionalinfo">
+                                    <div class="row">
+                                        <div class="form-group form-group-md col-xs-12 col-md-6">
+                                            <label for="ownerEmail"><span class="weight600">&#42;</span>Email address <a href="#" data-toggle="tooltip" title="The USPTO will use this email address to send correspondence regarding this application or registration. It is critical to ensure this email address is current." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
+                                            <input type="text" class="form-control" id="ownerEmail"   th:value="${owner.email}" >
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-md-6">
+                                            <label for="webaddress">Website address</label>
+                                            <input type="text" class="form-control" id="webaddress"  th:value="${owner.webSiteURL}">
+                                        </div>
                                         <div class="row">
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
-                                                <input type="text" class="form-control rounded-borders ge-name"  required  value="">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-sm-9">
-                                                <label><span class="weight600">&#42;</span>State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
-                                                <select  class="form-control ge-state">
-                                                    <option value="">Select</option>
-                                                    <option value="Alabama">Alabama</option>
-                                                    <option value="Alaska">Alaska</option>
-                                                    <option value="Arizona">Arizona</option>
-                                                    <option value="Arkansas">Arkansas</option>
-                                                    <option value="California">California</option>
-                                                    <option value="Colorado">Colorado</option>
-                                                    <option value="Connecticut">Connecticut</option>
-                                                    <option value="Delaware">Delaware</option>
-                                                    <option value="District of Columbia">District of Columbia</option>
-                                                    <option value="Florida">Florida</option>
-                                                    <option value="Georgia">Georgia</option>
-                                                    <option value="Hawaii">Hawaii</option>
-                                                    <option value="Idaho">Idaho</option>
-                                                    <option value="Illinois">Illinois</option>
-                                                    <option value="Indiana">Indiana</option>
-                                                    <option value="Iowa">Iowa</option>
-                                                    <option value="Kansas">Kansas</option>
-                                                    <option value="Kentucky">Kentucky</option>
-                                                    <option value="Louisiana">Louisiana</option>
-                                                    <option value="Maine">Maine</option>
-                                                    <option value="Maryland">Maryland</option>
-                                                    <option value="Massachusetts">Massachusetts</option>
-                                                    <option value="Michigan">Michigan</option>
-                                                    <option value="Minnesota">Minnesota</option>
-                                                    <option value="Mississippi">Mississippi</option>
-                                                    <option value="Missouri">Missouri</option>
-                                                    <option value="Montana">Montana</option>
-                                                    <option value="Nebraska">Nebraska</option>
-                                                    <option value="Nevada">Nevada</option>
-                                                    <option value="New Hampshire">New Hampshire</option>
-                                                    <option value="New Jersey">New Jersey</option>
-                                                    <option value="New Mexico">New Mexico</option>
-                                                    <option value="New York">New York</option>
-                                                    <option value="North Carolina">North Carolina</option>
-                                                    <option value="North Dakota">North Dakota</option>
-                                                    <option value="Ohio">Ohio</option>
-                                                    <option value="Oklahoma">Oklahoma</option>
-                                                    <option value="Oregon">Oregon</option>
-                                                    <option value="Pennsylvania">Pennsylvania</option>
-                                                    <option value="Rhode Island">Rhode Island</option>
-                                                    <option value="South Carolina">South Carolina</option>
-                                                    <option value="South Dakota">South Dakota</option>
-                                                    <option value="Tennessee">Tennessee</option>
-                                                    <option value="Texas">Texas</option>
-                                                    <option value="Utah">Utah</option>
-                                                    <option value="Vermont">Vermont</option>
-                                                    <option value="Virginia">Virginia</option>
-                                                    <option value="Washington">Washington</option>
-                                                    <option value="West Virginia">West Virginia</option>
-                                                    <option value="Wisconsin">Wisconsin</option>
-                                                    <option value="Wyoming">Wyoming</option>
-                                                </select>
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label>Type</label>
-                                                <span>
-                                                    <select class="form-control ge-name-type" >
-                                                        <option value="">Select</option>
-                                                        <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
-                                                        <option value="Trading As(TA)">Trading As(TA)</option>
-                                                        <option value="Also Known As(AKA)">Also Known As(AKA)</option>
-                                                        <option value="Formerly">Formerly</option>
+                                            <div class="col-xs-12">
+                                                <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-4">
+                                                    <label for="phonenumbertype">Phone type</label>
+                                                    <select class="form-control" id="phonenumbertype" name="phonenumbertype">
+                                                        <option value="Type">Type</option>
+                                                        <option value="Cell">Cell</option>
+                                                        <option value="Home">Home</option>
+                                                        <option value="Work">Work</option>
+                                                        <option value="Fax">Fax</option>
                                                     </select>
-                                            </span>
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-md-6 col-lg-6">
+                                                    <label for="phone">Phone number</label>
+                                                    <input type="text" class="form-control" id="phone" th:value="${owner.primaryPhonenumber}">
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-md-2 col-lg-2">
+                                                    <label for="extension">Ext.</label>
+                                                    <input type="text" class="form-control" id="extension">
+                                                </div>
                                             </div>
-                                            <div class="form-group form-group-md col-xs-6" style="">
-                                                <label for="nameoftype">Name</label>
-                                                <input type="text" class="form-control partner-alt-name"  name="nameoftype" ><!--needs th:attribute-->
+                                        </div>
+                                        <div class="row" style="display:none; max-height: 1px;">
+                                        </div>
+                                    </div>
+                                </fieldset>
+                                <div class="inlinebuttons btn-group btn-group-justified  owner-form-buttons" role="navigation" aria-label="view previous or next page" id="prevnxt">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm btn-primary fill next" id="doneButton" value="next" >Done
+                                            <div class="round"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
                                             </div>
-                                        </div>
-                                    </fieldset>
-                                </div> <!-- end of arrary dto object -->
-                            </div>
-                        </div>
-                        <!--END hidden content-->
-                        <div class="appendpartner col-xs-12"></div>
-                        <div class="row" id="hideshow_addpartner">
-
-                            <div class="col-xs-12 form-group form-group-md" aria-label="add a partner">
-                                <div class="inlinebuttons btn-group btn-group-justified">
-                                    <div class="btn-group col-xs-6">
-                                        <button type="button" class="btn btn-sm btn-success addinitial" id="addpartner">Add Partner</button>
+                                        </button>
                                     </div>
                                 </div>
-                            </div><!--// add button-->
-                        </div><!--// hide / show add partner-->
-                        <!--END Sole Proprietor Information Form-->
-                        <!--START Owner Address Information Form-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="addressinfo">Owner Address Information</h2>
+                                <!--END Additional Information Form-->
+                            </div><!--END Content Div-->
                         </div>
-                        <fieldset aria-labelledby="addressinfo">
-                            <div class="row">
-                                <div class="form-group form-group-md col-md-12 col-lg-7">
-                                    <label for="OwnerAddressCountry"><span class="weight600">&#42;</span>Country / U.S. territory</label>
-                                    <select class="form-control" id="OwnerAddressCountry" name="territory" th:field="${owner.country}" >
-                                        <option value="">Select</option>
-                                        <option value="United States of America">United States of America</option>
-                                        <option value="Afghanistan">Afghanistan</option>
-                                        <option value="Albania">Albania</option>
-                                        <option value="Algeria">Algeria</option>
-                                        <option value="American Samoa">American Samoa</option>
-                                        <option value="Andorra">Andorra</option>
-                                        <option value="Angola">Angola</option>
-                                        <option value="Anguilla">Anguilla</option>
-                                        <option value="Antarctica">Antarctica</option>
-                                        <option value="Antigua and Barbuda">Antigua and Barbuda</option>
-                                        <option value="Argentina">Argentina</option>
-                                        <option value="Armenia">Armenia</option>
-                                        <option value="Aruba">Aruba</option>
-                                        <option value="Australia">Australia</option>
-                                        <option value="Austria">Austria</option>
-                                        <option value="Azerbaijan">Azerbaijan</option>
-                                        <option value="Bahamas">Bahamas</option>
-                                        <option value="Bahrain">Bahrain</option>
-                                        <option value="Bangladesh">Bangladesh</option>
-                                        <option value="Barbados">Barbados</option>
-                                        <option value="Belarus">Belarus</option>
-                                        <option value="Belgium">Belgium</option>
-                                        <option value="Belize">Belize</option>
-                                        <option value="Benin">Benin</option>
-                                        <option value="Bermuda">Bermuda</option>
-                                        <option value="Bhutan">Bhutan</option>
-                                        <option value="Bolivia">Bolivia</option>
-                                        <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
-                                        <option value="Botswana">Botswana</option>
-                                        <option value="Bouvet Island">Bouvet Island</option>
-                                        <option value="Brazil">Brazil</option>
-                                        <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
-                                        <option value="Brunei Darussalam">Brunei Darussalam</option>
-                                        <option value="Bulgaria">Bulgaria</option>
-                                        <option value="Burkina Faso">Burkina Faso</option>
-                                        <option value="Burundi">Burundi</option>
-                                        <option value="Canada">Canada</option>
-                                        <option value="Cambodia">Cambodia</option>
-                                        <option value="Cameroon">Cameroon</option>
-                                        <option value="Cape Verde">Cape Verde</option>
-                                        <option value="Cayman Islands">Cayman Islands</option>
-                                        <option value="Central African Republic">Central African Republic</option>
-                                        <option value="Chad">Chad</option>
-                                        <option value="Chile">Chile</option>
-                                        <option value="China">China</option>
-                                        <option value="Christmas Island">Christmas Island</option>
-                                        <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
-                                        <option value="Colombia">Colombia</option>
-                                        <option value="Comoros">Comoros</option>
-                                        <option value="Congo">Congo</option>
-                                        <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
-                                        <option value="Cook Islands">Cook Islands</option>
-                                        <option value="Costa Rica">Costa Rica</option>
-                                        <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
-                                        <option value="Croatia">Croatia</option>
-                                        <option value="Cuba">Cuba</option>
-                                        <option value="Cyprus">Cyprus</option>
-                                        <option value="Czech Republic">Czech Republic</option>
-                                        <option value="Denmark">Denmark</option>
-                                        <option value="Djibouti">Djibouti</option>
-                                        <option value="Dominica">Dominica</option>
-                                        <option value="Dominican Republic">Dominican Republic</option>
-                                        <option value="East Timor">East Timor</option>
-                                        <option value="Ecuador">Ecuador</option>
-                                        <option value="Egypt">Egypt</option>
-                                        <option value="El Salvador">El Salvador</option>
-                                        <option value="Equatorial Guinea">Equatorial Guinea</option>
-                                        <option value="Eritrea">Eritrea</option>
-                                        <option value="Estonia">Estonia</option>
-                                        <option value="Ethiopia">Ethiopia</option>
-                                        <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
-                                        <option value="Faroe Islands">Faroe Islands</option>
-                                        <option value="Fiji">Fiji</option>
-                                        <option value="Finland">Finland</option>
-                                        <option value="France">France</option>
-                                        <option value="French Guiana">French Guiana</option>
-                                        <option value="French Polynesia">French Polynesia</option>
-                                        <option value="French Southern Territories">French Southern Territories</option>
-                                        <option value="Gabon">Gabon</option>
-                                        <option value="Gambia">Gambia</option>
-                                        <option value="Georgia">Georgia</option>
-                                        <option value="Germany">Germany</option>
-                                        <option value="Ghana">Ghana</option>
-                                        <option value="Gibraltar">Gibraltar</option>
-                                        <option value="Greece">Greece</option>
-                                        <option value="Greenland">Greenland</option>
-                                        <option value="Grenada">Grenada</option>
-                                        <option value="Guadeloupe">Guadeloupe</option>
-                                        <option value="Guam">Guam</option>
-                                        <option value="Guatemala">Guatemala</option>
-                                        <option value="Guinea">Guinea</option>
-                                        <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
-                                        <option value="Guyana">Guyana</option>
-                                        <option value="Haiti">Haiti</option>
-                                        <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
-                                        <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
-                                        <option value="Honduras">Honduras</option>
-                                        <option value="Hong Kong">Hong Kong</option>
-                                        <option value="Hungary">Hungary</option>
-                                        <option value="Iceland">Iceland</option>
-                                        <option value="India">India</option>
-                                        <option value="Indonesia">Indonesia</option>
-                                        <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
-                                        <option value="Iraq">Iraq</option>
-                                        <option value="Ireland">Ireland</option>
-                                        <option value="Israel">Israel</option>
-                                        <option value="Italy">Italy</option>
-                                        <option value="Jamaica">Jamaica</option>
-                                        <option value="Japan">Japan</option>
-                                        <option value="Jordan">Jordan</option>
-                                        <option value="Kazakstan">Kazakstan</option>
-                                        <option value="Kenya">Kenya</option>
-                                        <option value="Kiribati">Kiribati</option>
-                                        <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
-                                        <option value="Korea, Republic of">Korea, Republic of</option>
-                                        <option value="Kuwait">Kuwait</option>
-                                        <option value="Kyrgyzstan">Kyrgyzstan</option>
-                                        <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
-                                        <option value="Latvia">Latvia</option>
-                                        <option value="Lebanon">Lebanon</option>
-                                        <option value="Lesotho">Lesotho</option>
-                                        <option value="Liberia">Liberia</option>
-                                        <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
-                                        <option value="Liechtenstein">Liechtenstein</option>
-                                        <option value="Lithuania">Lithuania</option>
-                                        <option value="Luxembourg">Luxembourg</option>
-                                        <option value="Macau">Macau</option>
-                                        <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
-                                        <option value="Madagascar">Madagascar</option>
-                                        <option value="Malawi">Malawi</option>
-                                        <option value="Malaysia">Malaysia</option>
-                                        <option value="Maldives">Maldives</option>
-                                        <option value="Mali">Mali</option>
-                                        <option value="Malta">Malta</option>
-                                        <option value="Marshall Islands">Marshall Islands</option>
-                                        <option value="Martinique">Martinique</option>
-                                        <option value="Mauritania">Mauritania</option>
-                                        <option value="Mauritius">Mauritius</option>
-                                        <option value="Mayotte">Mayotte</option>
-                                        <option value="Mexico">Mexico</option>
-                                        <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
-                                        <option value="Moldova, Republic of">Moldova, Republic of</option>
-                                        <option value="Monaco">Monaco</option>
-                                        <option value="Mongolia">Mongolia</option>
-                                        <option value="Montserrat">Montserrat</option>
-                                        <option value="Morocco">Morocco</option>
-                                        <option value="Mozambique">Mozambique</option>
-                                        <option value="Myanmar">Myanmar</option>
-                                        <option value="Namibia">Namibia</option>
-                                        <option value="Nauru">Nauru</option>
-                                        <option value="Nepal">Nepal</option>
-                                        <option value="Netherlands">Netherlands</option>
-                                        <option value="Netherlands Antilles">Netherlands Antilles</option>
-                                        <option value="New Caledonia">New Caledonia</option>
-                                        <option value="New Zealand">New Zealand</option>
-                                        <option value="Nicaragua">Nicaragua</option>
-                                        <option value="Niger">Niger</option>
-                                        <option value="Nigeria">Nigeria</option>
-                                        <option value="Niue">Niue</option>
-                                        <option value="Norfolk Island">Norfolk Island</option>
-                                        <option value="Northern Mariana Islands">Northern Mariana Islands</option>
-                                        <option value="Norway">Norway</option>
-                                        <option value="Oman">Oman</option>
-                                        <option value="Pakistan">Pakistan</option>
-                                        <option value="Palau">Palau</option>
-                                        <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
-                                        <option value="Panama">Panama</option>
-                                        <option value="Papua New Guinea">Papua New Guinea</option>
-                                        <option value="Paraguay">Paraguay</option>
-                                        <option value="Peru">Peru</option>
-                                        <option value="Philippines">Philippines</option>
-                                        <option value="Pitcairn">Pitcairn</option>
-                                        <option value="Poland">Poland</option>
-                                        <option value="Portugal">Portugal</option>
-                                        <option value="Puerto Rico">Puerto Rico</option>
-                                        <option value="Qatar">Qatar</option>
-                                        <option value="Reunion">Reunion</option>
-                                        <option value="Romania">Romania</option>
-                                        <option value="Russian Federation">Russian Federation</option>
-                                        <option value="Rwanda">Rwanda</option>
-                                        <option value="Saint Helena">Saint Helena</option>
-                                        <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
-                                        <option value="Saint Lucia">Saint Lucia</option>
-                                        <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
-                                        <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
-                                        <option value="Samoa">Samoa</option>
-                                        <option value="San Marino">San Marino</option>
-                                        <option value="Sao Tome and Principe">Sao Tome and Principe</option>
-                                        <option value="Saudi Arabia">Saudi Arabia</option>
-                                        <option value="Senegal">Senegal</option>
-                                        <option value="Seychelles">Seychelles</option>
-                                        <option value="Sierra Leone">Sierra Leone</option>
-                                        <option value="Singapore">Singapore</option>
-                                        <option value="Slovakia">Slovakia</option>
-                                        <option value="Slovenia">Slovenia</option>
-                                        <option value="Solomon Islands">Solomon Islands</option>
-                                        <option value="Somalia">Somalia</option>
-                                        <option value="South Africa">South Africa</option>
-                                        <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
-                                        <option value="Spain">Spain</option>
-                                        <option value="Sri Lanka">Sri Lanka</option>
-                                        <option value="Sudan">Sudan</option>
-                                        <option value="Suriname">Suriname</option>
-                                        <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
-                                        <option value="Swaziland">Swaziland</option>
-                                        <option value="Sweden">Sweden</option>
-                                        <option value="Switzerland">Switzerland</option>
-                                        <option value="Syrian Arab Republic">Syrian Arab Republic</option>
-                                        <option value="Taiwan">Taiwan</option>
-                                        <option value="Tajikistan">Tajikistan</option>
-                                        <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
-                                        <option value="Thailand">Thailand</option>
-                                        <option value="Togo">Togo</option>
-                                        <option value="Tokelau">Tokelau</option>
-                                        <option value="Tonga">Tonga</option>
-                                        <option value="Trinidad and Tobago">Trinidad and Tobago</option>
-                                        <option value="Tunisia">Tunisia</option>
-                                        <option value="Turkey">Turkey</option>
-                                        <option value="Turkmenistan">Turkmenistan</option>
-                                        <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
-                                        <option value="Tuvalu">Tuvalu</option>
-                                        <option value="Uganda">Uganda</option>
-                                        <option value="Ukraine">Ukraine</option>
-                                        <option value="United Arab Emirates">United Arab Emirates</option>
-                                        <option value="United Kingdom">United Kingdom</option>
-                                        <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
-                                        <option value="Uruguay">Uruguay</option>
-                                        <option value="Uzbekistan">Uzbekistan</option>
-                                        <option value="Vanuatu">Vanuatu</option>
-                                        <option value="Venezuela">Venezuela</option>
-                                        <option value="Viet Nam">Viet Nam</option>
-                                        <option value="Virgin Islands, British">Virgin Islands, British</option>
-                                        <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
-                                        <option value="Wallis and Futuna">Wallis and Futuna</option>
-                                        <option value="Western Sahara">Western Sahara</option>
-                                        <option value="Yemen">Yemen</option>
-                                        <option value="Yugoslavia">Yugoslavia</option>
-                                        <option value="Zambia">Zambia</option>
-                                        <option value="Zimbabwe">Zimbabwe</option>
-                                        <option value="Unknown">Unknown</option>
-                                    </select>
-                                </div>
-                                <div class="form-group form-group-md col-md-12 col-lg-9">
-                                    <label for="ownerAddress1"><span class="weight600">&#42;</span>Address line 1</label>
-                                    <input type="text" class="form-control" id="ownerAddress1" th:value="${owner.address1}" >
-                                </div>
-                                <div class="form-group form-group-md col-md-12 col-lg-9">
-                                    <label for="addressline2">Address line 2</label>
-                                    <input type="text" class="form-control" id="addressline2" >
-                                </div>
-                                <div class="form-group form-group-md col-md-12 col-lg-9">
-                                    <label for="addressline3">Address line 3</label>
-                                    <input type="text" class="form-control" id="addressline3" >
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                    <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
-                                    <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}">
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                    <label for="ownerState"><span class="weight600">&#42;</span>State/Province/Territory</label>
-                                    <select class="form-control" id="ownerState" th:field="${owner.state}" required>
-                                        <option value="">Select</option>
-                                        <option value="Alabama">Alabama</option>
-                                        <option value="Alaska">Alaska</option>
-                                        <option value="Arizona">Arizona</option>
-                                        <option value="Arkansas">Arkansas</option>
-                                        <option value="California">California</option>
-                                        <option value="Colorado">Colorado</option>
-                                        <option value="Connecticut">Connecticut</option>
-                                        <option value="Delaware">Delaware</option>
-                                        <option value="District of Columbia">District of Columbia</option>
-                                        <option value="Florida">Florida</option>
-                                        <option value="Georgia">Georgia</option>
-                                        <option value="Hawaii">Hawaii</option>
-                                        <option value="Idaho">Idaho</option>
-                                        <option value="Illinois">Illinois</option>
-                                        <option value="Indiana">Indiana</option>
-                                        <option value="Iowa">Iowa</option>
-                                        <option value="Kansas">Kansas</option>
-                                        <option value="Kentucky">Kentucky</option>
-                                        <option value="Louisiana">Louisiana</option>
-                                        <option value="Maine">Maine</option>
-                                        <option value="Maryland">Maryland</option>
-                                        <option value="Massachusetts">Massachusetts</option>
-                                        <option value="Michigan">Michigan</option>
-                                        <option value="Minnesota">Minnesota</option>
-                                        <option value="Mississippi">Mississippi</option>
-                                        <option value="Missouri">Missouri</option>
-                                        <option value="Montana">Montana</option>
-                                        <option value="Nebraska">Nebraska</option>
-                                        <option value="Nevada">Nevada</option>
-                                        <option value="New Hampshire">New Hampshire</option>
-                                        <option value="New Jersey">New Jersey</option>
-                                        <option value="New Mexico">New Mexico</option>
-                                        <option value="New York">New York</option>
-                                        <option value="North Carolina">North Carolina</option>
-                                        <option value="North Dakota">North Dakota</option>
-                                        <option value="Ohio">Ohio</option>
-                                        <option value="Oklahoma">Oklahoma</option>
-                                        <option value="Oregon">Oregon</option>
-                                        <option value="Pennsylvania">Pennsylvania</option>
-                                        <option value="Rhode Island">Rhode Island</option>
-                                        <option value="South Carolina">South Carolina</option>
-                                        <option value="South Dakota">South Dakota</option>
-                                        <option value="Tennessee">Tennessee</option>
-                                        <option value="Texas">Texas</option>
-                                        <option value="Utah">Utah</option>
-                                        <option value="Vermont">Vermont</option>
-                                        <option value="Virginia">Virginia</option>
-                                        <option value="Washington">Washington</option>
-                                        <option value="West Virginia">West Virginia</option>
-                                        <option value="Wisconsin">Wisconsin</option>
-                                        <option value="Wyoming">Wyoming</option>
-                                    </select>
-
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-5">
-                                    <label for="ownerZipcode"><span class="weight600">&#42;</span>Zip code/Postal code</label>
-                                    <input type="text" class="form-control" id="ownerZipcode" placeholder=""  th:value="${owner.zipcode}">
-                                </div>
-                            </div>
-                        </fieldset>
-                        <!--END Owner Address Information Form-->
-                        <!--START Additional Information Form-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="additionalinfo">Additional Information</h2>
-                        </div>
-                        <fieldset aria-labelledby="additionalinfo">
-                            <div class="row">
-                                <div class="form-group form-group-md col-xs-12 col-md-6">
-                                    <label for="ownerEmail"><span class="weight600">&#42;</span>Email address <a href="#" data-toggle="tooltip" title="The USPTO will use this email address to send correspondence regarding this application or registration. It is critical to ensure this email address is current." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
-                                    <input type="text" class="form-control" id="ownerEmail"   th:value="${owner.email}" >
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-md-6">
-                                    <label for="webaddress">Website address</label>
-                                    <input type="text" class="form-control" id="webaddress"  th:value="${owner.webSiteURL}">
-                                </div>
-                                <div class="row">
-                                    <div class="col-xs-12">
-                                        <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-4">
-                                            <label for="phonenumbertype">Phone type</label>
-                                            <select class="form-control" id="phonenumbertype" name="phonenumbertype">
-                                                <option value="Type">Type</option>
-                                                <option value="Cell">Cell</option>
-                                                <option value="Home">Home</option>
-                                                <option value="Work">Work</option>
-                                                <option value="Fax">Fax</option>
-                                            </select>
-                                        </div>
-                                        <div class="form-group form-group-md col-xs-12 col-md-6 col-lg-6">
-                                            <label for="phone">Phone number</label>
-                                            <input type="text" class="form-control" id="phone" th:value="${owner.primaryPhonenumber}">
-                                        </div>
-                                        <div class="form-group form-group-md col-xs-12 col-md-2 col-lg-2">
-                                            <label for="extension">Ext.</label>
-                                            <input type="text" class="form-control" id="extension">
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="row" style="display:none; max-height: 1px;">
-                                </div>
-                            </div>
-                        </fieldset>
-                        <div class="inlinebuttons btn-group btn-group-justified  owner-form-buttons" role="navigation" aria-label="view previous or next page" id="prevnxt">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm btn-primary fill next" id="doneButton" value="next" >Done
-                                    <div class="round"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
-                                    </div>
-                                </button>
-                            </div>
-                        </div>
-                        <!--END Additional Information Form-->
-                    </div><!--END Content Div-->
+                    </div><!--END container div-->
                 </div>
-            </div><!--END container div-->
+            </main>
         </div>
-    </main>
-</div>
+    </div>
 
 <!--load model attribute for Jquery consumption  -->
 <script th:inline="javascript">

--- a/PTO-WEB/src/main/resources/templates/application/owner/llc/ownerInfo2.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/llc/ownerInfo2.html
@@ -80,7 +80,7 @@
                                 </select>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                 <select class="form-control" id="additional-name-type" th:field="*{ownerType}">
                                     <option value="">Select</option>
                                     <option value="DBA">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/owner/llc/ownerInfoEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/llc/ownerInfoEdit.html
@@ -6,7 +6,8 @@
     <title>Owner Information</title>
 </head>
 <body>
-<div class="row content"  style="display: none;">
+    <div class="container-fluid">
+        <div class="row content"  style="display: none;">
     <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
         <div class="row" >
             <div class="col-xs-12">
@@ -91,13 +92,13 @@
                         </div>
                         <fieldset aria-labelledby="ownerinfo">
                             <div class="row">
-                                <div class="form-group form-group-md col-xs-6">
+                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
                                     <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
                                     <input type="text" class="form-control"  id="ownername" th:value="${owner.ownerDisplayname}">
                                 </div>
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="stateoforg"><span class="weight600">&#42;</span>State where legally organized<span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
-                                    <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}"  >
+                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                    <label for="stateoforg"><span class="weight600">&#42;</span>State where legally organized</label>
+                                    <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}" required>
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>
                                         <option value="Alaska">Alaska</option>
@@ -152,8 +153,8 @@
                                         <option value="Wyoming">Wyoming</option>
                                     </select>
                                 </div>
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" id="additional-name-type"  th:field="${owner.ownerType}">
                                         <option value="">Select</option>
                                         <option value="DBA">Doing Business As (DBA)</option>
@@ -164,14 +165,14 @@
                                 </div>
 
                                 <th:block  th:if="${owner.isAlternameSet() == true}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype">
                                         <label for="nameoftype">Name</label>
                                         <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
                                     </div>
                                 </th:block>
 
                                 <th:block  th:if="${owner.isAlternameSet() == false}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype" style="display: none;">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype" style="display: none;">
                                         <label for="nameoftype">Name</label>
                                         <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
                                     </div>
@@ -448,11 +449,11 @@
                                     <label for="addressline3">Address line 3</label>
                                     <input type="text" class="form-control" id="addressline3" >
                                 </div>
-                                <div class="form-group form-group-md col-xs-4">
+                                <div class="form-group form-group-md col-xs-12 col-sm-6">
                                     <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
                                     <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}" >
                                 </div>
-                                <div class="form-group form-group-md col-xs-4">
+                                <div class="form-group form-group-md col-xs-12 col-sm-6">
                                     <label for="ownerState"><span class="weight600">&#42;</span>State/Province/Territory</label>
                                     <select class="form-control" id="ownerState" th:field="${owner.state}" required>
                                         <option value="">Select</option>
@@ -509,7 +510,7 @@
                                         <option value="Wyoming">Wyoming</option>
                                     </select>
                                 </div>
-                                <div class="form-group form-group-md col-xs-5">
+                                <div class="form-group form-group-md col-xs-12 col-sm-5">
                                     <label for="ownerZipcode"><span class="weight600">&#42;</span>Zip code/Postal code</label>
                                     <input type="text" class="form-control" id="ownerZipcode" placeholder="" th:value="${owner.zipcode}">
                                 </div>
@@ -569,6 +570,7 @@
         </div>
     </main>
 </div>
+    </div>
 
 <!--load model attribute for Jquery consumption  -->
 <script th:inline="javascript">

--- a/PTO-WEB/src/main/resources/templates/application/owner/llp/ownerInfo.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/llp/ownerInfo.html
@@ -26,10 +26,10 @@
                         <div class="row">
                             <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
                                 <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
-                                <input type="text" class="form-control"  id="ownername" th:field="*{ownerName}" required>
+                                <input type="text" class="form-control" id="ownername" th:field="*{ownerName}" required>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                <label for="stateoforg">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                <label for="stateoforg">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                 <select class="form-control" id="stateoforg" th:field="*{ownerOrganizationState}" required>
                                     <option value="">Select</option>
                                     <option value="Alabama">Alabama</option>
@@ -87,7 +87,7 @@
                                 </select>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                 <select class="form-control" id="additional-name-type" th:field="*{ownerType}">
                                     <option value="">Select</option>
                                     <option value="DBA">Doing Business As (DBA)</option>
@@ -137,7 +137,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input  class="form-control" id="partner-suffix" th:field="*{partnerDTOs[__${itemStat.index}__].suffix}" name="suffix" />
+                                    <input type="text" class="form-control" id="partner-suffix" th:field="*{partnerDTOs[__${itemStat.index}__].suffix}" name="suffix" />
 
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
@@ -395,7 +395,7 @@
                                     <input id="partner-owner-name" type="text" th:field="*{partnerDTOs[__${itemStat.index}__].partnerName}"  class="form-control rounded-borders"   required>
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="partner-owner-name-state">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label for="partner-owner-name-state">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select id="partner-owner-name-state" th:field="*{partnerDTOs[__${itemStat.index}__].state}"  class="form-control" name="State"  required>
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>
@@ -452,7 +452,7 @@
                                         <option value="N/A">N/A</option>
                                     </select>
                                 </div>
-                                <div class="form-group form-group-md col-xs-6">
+                                <div class="form-group form-group-md col-xs-12 col-sm-6">
                                     <label>&#42;Type</label>
                                     <span>
                                     <select id="partner-owner-name-type" class="form-control partner-owner-name-type" name="nameType" th:field="*{partnerDTOs[__${itemStat.index}__].type}">
@@ -464,7 +464,7 @@
                                     </select>
                                 </span>
                                 </div>
-                                <div class="form-group form-group-md col-xs-6" id="partner-add-Name-value" style="display: none;">
+                                <div class="form-group form-group-md col-xs-12 col-sm-6" id="partner-add-Name-value" style="display: none;">
                                     <label for="nameoftype">Name</label>
                                     <input type="text" class="form-control" id="partner-add-name" name="nameoftype"  th:field="*{partnerDTOs[__${itemStat.index}__].alternateName}"><!--needs th:attribute-->
                                 </div>
@@ -505,7 +505,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input  class="form-control" id="partner-suffix2" name="suffix" th:field="*{partner_suffix2}" />
+                                    <input type="text" class="form-control" id="partner-suffix2" name="suffix" th:field="*{partner_suffix2}" />
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
                                     <label for="partner-citizenship">Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
@@ -758,11 +758,11 @@
                         <fieldset aria-labelledby="proprietorinfo" id="none-individual-partner-entity2" style="display: none;">
                             <div class="row">
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="ownername"><b style="color: red">&#42;</b>Owner name</label>
+                                    <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
                                     <input id="partner-owner-name2" type="text"  class="form-control rounded-borders"  th:field="*{partner_name2}"  >
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="partner-owner-name-state2">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label for="partner-owner-name-state2">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select id="partner-owner-name-state2" class="form-control" name="State" th:field="*{partner_state_org2}"  >
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>
@@ -871,11 +871,11 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input  class="form-control" id="partner-suffix3" name="suffix"  th:field="*{partner_suffix3}" />
+                                    <input type="text" class="form-control" id="partner-suffix3" name="suffix"  th:field="*{partner_suffix3}" />
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
                                     <label for="partner-citizenship">Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
-                                    <select id="partner-citizenship3" class="form-control" name="owner-citizenship" th:field="*{partner_citizen3}" >
+                                    <select id="partner-citizenship3" class="form-control" name="owner-citizenship" th:field="*{partner_citizen3}">
                                         <option value="">Select</option>
                                         <option value="United States of America">United States of America</option>
                                         <option value="Afghanistan">Afghanistan</option>
@@ -1128,7 +1128,7 @@
                                     <input id="partner-owner-name3" type="text" class="form-control rounded-borders" th:field="*{partner_name3}"  >
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="partner-owner-name-state3">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label for="partner-owner-name-state3">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select id="partner-owner-name-state3"  class="form-control" name="State" th:field="*{partner_state_org3}" >
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>

--- a/PTO-WEB/src/main/resources/templates/application/owner/llp/ownerInfoEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/llp/ownerInfoEdit.html
@@ -6,7 +6,8 @@
     <title>Owner Information</title>
 </head>
 <body>
-<div class="row content"  style="display: none;">
+    <div class="container-fluid">
+        <div class="row content"  style="display: none;">
     <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
         <div class="row" >
             <div class="col-xs-12">
@@ -92,12 +93,12 @@
                         <div id="partnerEntitydynamicFormArea">
                             <fieldset aria-labelledby="ownerinfo">
                                 <div class="row">
-                                    <div class="form-group form-group-md col-xs-6">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
                                         <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
-                                        <input type="text" class="form-control"  id="ownername"  th:value="${owner.ownerDisplayname}">
+                                        <input type="text" class="form-control" id="ownername"  th:value="${owner.ownerDisplayname}">
                                     </div>
-                                    <div class="form-group form-group-md col-xs-6">
-                                        <label for="stateoforg"><span class="weight600">&#42;</span>State where legally organized <span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
+                                    <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                        <label for="stateoforg">State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
                                         <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}" >
                                             <option value="">Select</option>
                                             <option value="Alabama">Alabama</option>
@@ -153,8 +154,8 @@
                                             <option value="Wyoming">Wyoming</option>
                                         </select>
                                     </div>
-                                    <div class="form-group form-group-md col-xs-6">
-                                        <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                        <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                         <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
                                             <option value="Select">Select</option>
                                             <option value="DBA">Doing Business As (DBA)</option>
@@ -166,14 +167,14 @@
 
 
                                     <th:block  th:if="${owner.isAlternameSet() == true}">
-                                        <div class="form-group form-group-md col-xs-6" id="nametype">
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype">
                                             <label for="nameoftype">Name</label>
                                             <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
                                         </div>
                                     </th:block>
 
                                     <th:block  th:if="${owner.isAlternameSet() == false}">
-                                        <div class="form-group form-group-md col-xs-6" id="nametype" style="display: none;">
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype" style="display: none;">
                                             <label for="nameoftype">Name</label>
                                             <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
                                         </div>
@@ -209,12 +210,12 @@
                                                 <label><span class="weight600">&#42;</span>Last name</label>
                                                 <input type="text" name="lastName" class="form-control ge-last-name" th:value="${exceuter.lastName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
                                             </div>
-                                            <div class="form-group form-group-md col-xs-6">
+                                            <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                                 <label>Suffix</label>
-                                                <input class="form-control ge-suffix" name="suffix" />
+                                                <input type="text" class="form-control ge-suffix" name="suffix" />
                                             </div>
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label ><span class="weight600">&#42;</span>Country of citizenship</label>
+                                            <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
+                                                <label>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                                 <select class="form-control ge-citizenship" name="owner-citizenship" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
                                                     <option th:value="${exceuter.entityCitizenship}" th:text="${exceuter.entityCitizenship}" selected th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"></option>
                                                     <option value="">Select</option>
@@ -463,13 +464,13 @@
                                         </th:block>
 
                                         <th:block th:if="${exceuter.isPersonEntity() == false}">
-                                            <div class="form-group form-group-md col-xs-6">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
                                                 <label><span class="weight600">&#42;</span>Owner name</label>
                                                 <input type="text" class="form-control rounded-borders ge-name" style="" th:value="${exceuter.entityName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
                                             </div>
 
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label><span class="weight600">&#42;</span>State where legally organized</label>
+                                            <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                <label>State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
                                                 <select class="form-control ge-state" name="State" th:attr="entity-index=${iter.index}" >
                                                     <option  th:value="${exceuter.organizationState}"  th:text="${exceuter.organizationState}"  th:attr="entity-id=${exceuter.id}"selected></option>
                                                     <option value="">Select</option>
@@ -526,8 +527,8 @@
                                                     <option value="Wyoming">Wyoming</option>
                                                 </select>
                                             </div>
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label>Type</label>
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                <label>Type <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
                                                 <span>
                                                 <select class="form-control ge-name-type" name="nameType"   style="" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
                                                     <option th:value="${exceuter.getEntityAlternateNameType()}" th:text="${exceuter.getEntityAlternateNameType()}" selected>Select</option>
@@ -539,7 +540,7 @@
                                                 </select>
                                             </span>
                                             </div>
-                                            <div class="form-group form-group-md col-xs-6" style="">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6" style="">
                                                 <label for="nameoftype">Name</label>
                                                 <input type="text" class="form-control partner-alt-name"  name="nameoftype" th:value="${exceuter.getEntityAlternateName()}"   th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"><!--needs th:attribute-->
                                             </div>
@@ -582,13 +583,13 @@
                                                     <label ><span class="weight600">&#42;</span>Last name</label>
                                                     <input  type="text" class="form-control ge-last-name" required value="">
                                                 </div>
-                                                <div class="form-group form-group-md col-xs-6">
+                                                <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                                     <label for="partner-suffix">Suffix</label>
-                                                    <input class="form-control" id="partner-suffix" value="">
+                                                    <input type="text" class="form-control" id="partner-suffix" value="">
                                                 </div>
-                                                <div class="form-group form-group-md col-xs-6">
-                                                    <label ><span class="weight600">&#42;</span>Country of citizenship</label>
-                                                    <select class="form-control ge-citizenship" required="">
+                                                <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
+                                                    <label>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                                    <select class="form-control ge-citizenship">
                                                         <option value="">Select</option>
                                                         <option value="United States of America">United States of America</option>
                                                         <option value="Afghanistan">Afghanistan</option>
@@ -836,12 +837,12 @@
                                         </fieldset>
                                         <fieldset aria-labelledby="proprietorinfo" id="none-individual-partner-entity-new" style="display: none;">
                                             <div class="row">
-                                                <div class="form-group form-group-md col-xs-6">
+                                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
                                                     <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
                                                     <input type="text" class="form-control rounded-borders ge-name"  required  value="">
                                                 </div>
-                                                <div class="form-group form-group-md col-xs-6">
-                                                    <label><span class="weight600">&#42;</span>State where legally organized</label>
+                                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                    <label>State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                                     <select class="form-control ge-state">
                                                         <option value="">Select</option>
                                                         <option value="Alabama">Alabama</option>
@@ -897,19 +898,19 @@
                                                         <option value="Wyoming">Wyoming</option>
                                                     </select>
                                                 </div>
-                                                <div class="form-group form-group-md col-xs-6">
-                                                    <label>Type</label>
+                                                <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                    <label>Type <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
                                                     <span>
                                                     <select class="form-control ge-name-type" >
-                                                          <option value="">Select</option>
-                                                            <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
-                                                            <option value="Trading As(TA)">Trading As(TA)</option>
-                                                            <option value="Also Known As(AKA)">Also Known As(AKA)</option>
-                                                            <option value="Formerly">Formerly</option>
+                                                      <option value="">Select</option>
+                                                        <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
+                                                        <option value="Trading As(TA)">Trading As(TA)</option>
+                                                        <option value="Also Known As(AKA)">Also Known As(AKA)</option>
+                                                        <option value="Formerly">Formerly</option>
                                                     </select>
                                                 </span>
                                                 </div>
-                                                <div class="form-group form-group-md col-xs-6" style="">
+                                                <div class="form-group form-group-md col-xs-12 col-sm-6" style="">
                                                     <label for="nameoftype">Name</label>
                                                     <input type="text" class="form-control partner-alt-name"  name="nameoftype" ><!--needs th:attribute-->
                                                 </div>
@@ -1195,12 +1196,12 @@
                                         <label for="addressline3">Address line 3</label>
                                         <input type="text" class="form-control" id="addressline3" >
                                     </div>
-                                    <div class="form-group form-group-md col-xs-4">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6">
                                         <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
                                         <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}">
                                     </div>
-                                    <div class="form-group form-group-md col-xs-4">
-                                        <label for="ownerState"><span class="weight600">&#42;</span>State</label>
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                        <label for="ownerState"><span class="weight600">&#42;</span>State/Province/Territory</label>
                                         <select class="form-control" id="ownerState" th:field="${owner.state}" required>
                                             <option value="">Select</option>
                                             <option value="Alabama">Alabama</option>
@@ -1256,7 +1257,7 @@
                                             <option value="Wyoming">Wyoming</option>
                                         </select>
                                     </div>
-                                    <div class="form-group form-group-md col-xs-5">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-5">
                                         <label for="ownerZipcode"><span class="weight600">&#42;</span>Zip code/Postal code</label>
                                         <input type="text" class="form-control" id="ownerZipcode" placeholder=""  th:value="${owner.zipcode}">
                                     </div>
@@ -1319,6 +1320,7 @@
         </div>
     </main>
 </div>
+    </div>
 
 <!--load model attribute for Jquery consumption  -->
 <script th:inline="javascript">

--- a/PTO-WEB/src/main/resources/templates/application/owner/partnership/ownerInfo2.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/partnership/ownerInfo2.html
@@ -30,7 +30,7 @@
                                 <input type="text" class="form-control"  id="ownername" th:field="*{ownerName}" required>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                <label for="stateoforg">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                <label for="stateoforg">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                 <select class="form-control" id="stateoforg" th:field="*{ownerOrganizationState}" required >
                                     <option value="">Select</option>
                                     <option value="Alabama">Alabama</option>
@@ -88,7 +88,7 @@
                                 </select>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                 <select class="form-control" id="additional-name-type" th:field="*{ownerType}">
                                     <option value="">Select</option>
                                     <option value="DBA">Doing Business As (DBA)</option>
@@ -490,7 +490,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input class="form-control" id="partner-suffix2" name="suffix" th:field="*{partner_suffix2}" />
+                                    <input type="text" class="form-control" id="partner-suffix2" name="suffix" th:field="*{partner_suffix2}" />
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
                                     <label for="partner-citizenship">Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
@@ -840,7 +840,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input  class="form-control" id="partner-suffix3" name="suffix" th:field="*{partner_suffix3}" />
+                                    <input type="text" class="form-control" id="partner-suffix3" name="suffix" th:field="*{partner_suffix3}" />
 
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
@@ -1094,7 +1094,7 @@
                         <fieldset aria-labelledby="proprietorinfo" id="none-individual-partner-entity3" style="display: none;">
                             <div class="row">
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label for="ownername"><b style="color: red">&#42;</b>General partner name</label>
+                                    <label for="ownername">&#42;General partner name</label>
                                     <input id="partner-owner-name3" type="text" class="form-control rounded-borders" th:field="*{partner_name3}"  >
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">

--- a/PTO-WEB/src/main/resources/templates/application/owner/partnership/ownerInfoEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/partnership/ownerInfoEdit.html
@@ -6,406 +6,100 @@
     <title>Owner Information</title>
 </head>
 <body>
-<div class="row content"  style="display: none;">
-    <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
-        <div class="row" >
-            <div class="col-xs-12">
-                <!--START Content Div-->
-                <div class="row">
-                    <section class="col-xs-12 steps breadcrumb-steps" aria-label="progress tracker">
-                        <div class="row displaycell">
-                            <div class="col-xs-2 one" id="bs-header1">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>1</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link1">
-                                        <p class="first">Your details</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 two" id="bs-header2">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>2</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link2">
-                                        <p>Trademark details</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 three" id="bs-header3">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>3</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link3">
-                                        <p>Goods and services</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 four" id="bs-header4">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>4</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link4">
-                                        <p>Basis</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 five" id="bs-header5">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>5</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link5">
-                                        <p>Additional info</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 six" id="bs-header6">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>6</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link6">
-                                        <p>Confirm and pay</p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-                </div>
-                <div class="row" style="">
-                    <div class="row">
-                        <div class="col-xs-6">
-                            <h1 style="margin-left: 15px;">Edit Owner Information</h1>
-
-                        </div>
-                    </div>
-                    <div class="col-xs-12 text-left">
-                        <!--START Owner Information Form-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="ownerinfo">Owner Information</h2>
-                        </div>
-                        <div id="partnerEntitydynamicFormArea">
-                            <fieldset aria-labelledby="ownerinfo">
-                                <div class="row">
-                                    <div class="form-group form-group-md col-xs-6">
-                                        <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
-                                        <input type="text" class="form-control"  id="ownername"  th:value="${owner.getOwnerName()}">
-                                    </div>
-                                    <div class="form-group form-group-md col-xs-6">
-                                        <label for="stateoforg">State where legally organized <span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
-                                        <select class="form-control" id="stateoforg" th:field="${owner.ownerOrganizationState}" >
-                                            <option value="">Select</option>
-                                            <option value="United States of America">United States of America</option>
-                                            <option value="Afghanistan">Afghanistan</option>
-                                            <option value="Albania">Albania</option>
-                                            <option value="Algeria">Algeria</option>
-                                            <option value="American Samoa">American Samoa</option>
-                                            <option value="Andorra">Andorra</option>
-                                            <option value="Angola">Angola</option>
-                                            <option value="Anguilla">Anguilla</option>
-                                            <option value="Antarctica">Antarctica</option>
-                                            <option value="Antigua and Barbuda">Antigua and Barbuda</option>
-                                            <option value="Argentina">Argentina</option>
-                                            <option value="Armenia">Armenia</option>
-                                            <option value="Aruba">Aruba</option>
-                                            <option value="Australia">Australia</option>
-                                            <option value="Austria">Austria</option>
-                                            <option value="Azerbaijan">Azerbaijan</option>
-                                            <option value="Bahamas">Bahamas</option>
-                                            <option value="Bahrain">Bahrain</option>
-                                            <option value="Bangladesh">Bangladesh</option>
-                                            <option value="Barbados">Barbados</option>
-                                            <option value="Belarus">Belarus</option>
-                                            <option value="Belgium">Belgium</option>
-                                            <option value="Belize">Belize</option>
-                                            <option value="Benin">Benin</option>
-                                            <option value="Bermuda">Bermuda</option>
-                                            <option value="Bhutan">Bhutan</option>
-                                            <option value="Bolivia">Bolivia</option>
-                                            <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
-                                            <option value="Botswana">Botswana</option>
-                                            <option value="Bouvet Island">Bouvet Island</option>
-                                            <option value="Brazil">Brazil</option>
-                                            <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
-                                            <option value="Brunei Darussalam">Brunei Darussalam</option>
-                                            <option value="Bulgaria">Bulgaria</option>
-                                            <option value="Burkina Faso">Burkina Faso</option>
-                                            <option value="Burundi">Burundi</option>
-                                            <option value="Canada">Canada</option>
-                                            <option value="Cambodia">Cambodia</option>
-                                            <option value="Cameroon">Cameroon</option>
-                                            <option value="Cape Verde">Cape Verde</option>
-                                            <option value="Cayman Islands">Cayman Islands</option>
-                                            <option value="Central African Republic">Central African Republic</option>
-                                            <option value="Chad">Chad</option>
-                                            <option value="Chile">Chile</option>
-                                            <option value="China">China</option>
-                                            <option value="Christmas Island">Christmas Island</option>
-                                            <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
-                                            <option value="Colombia">Colombia</option>
-                                            <option value="Comoros">Comoros</option>
-                                            <option value="Congo">Congo</option>
-                                            <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
-                                            <option value="Cook Islands">Cook Islands</option>
-                                            <option value="Costa Rica">Costa Rica</option>
-                                            <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
-                                            <option value="Croatia">Croatia</option>
-                                            <option value="Cuba">Cuba</option>
-                                            <option value="Cyprus">Cyprus</option>
-                                            <option value="Czech Republic">Czech Republic</option>
-                                            <option value="Denmark">Denmark</option>
-                                            <option value="Djibouti">Djibouti</option>
-                                            <option value="Dominica">Dominica</option>
-                                            <option value="Dominican Republic">Dominican Republic</option>
-                                            <option value="East Timor">East Timor</option>
-                                            <option value="Ecuador">Ecuador</option>
-                                            <option value="Egypt">Egypt</option>
-                                            <option value="El Salvador">El Salvador</option>
-                                            <option value="Equatorial Guinea">Equatorial Guinea</option>
-                                            <option value="Eritrea">Eritrea</option>
-                                            <option value="Estonia">Estonia</option>
-                                            <option value="Ethiopia">Ethiopia</option>
-                                            <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
-                                            <option value="Faroe Islands">Faroe Islands</option>
-                                            <option value="Fiji">Fiji</option>
-                                            <option value="Finland">Finland</option>
-                                            <option value="France">France</option>
-                                            <option value="French Guiana">French Guiana</option>
-                                            <option value="French Polynesia">French Polynesia</option>
-                                            <option value="French Southern Territories">French Southern Territories</option>
-                                            <option value="Gabon">Gabon</option>
-                                            <option value="Gambia">Gambia</option>
-                                            <option value="Georgia">Georgia</option>
-                                            <option value="Germany">Germany</option>
-                                            <option value="Ghana">Ghana</option>
-                                            <option value="Gibraltar">Gibraltar</option>
-                                            <option value="Greece">Greece</option>
-                                            <option value="Greenland">Greenland</option>
-                                            <option value="Grenada">Grenada</option>
-                                            <option value="Guadeloupe">Guadeloupe</option>
-                                            <option value="Guam">Guam</option>
-                                            <option value="Guatemala">Guatemala</option>
-                                            <option value="Guinea">Guinea</option>
-                                            <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
-                                            <option value="Guyana">Guyana</option>
-                                            <option value="Haiti">Haiti</option>
-                                            <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
-                                            <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
-                                            <option value="Honduras">Honduras</option>
-                                            <option value="Hong Kong">Hong Kong</option>
-                                            <option value="Hungary">Hungary</option>
-                                            <option value="Iceland">Iceland</option>
-                                            <option value="India">India</option>
-                                            <option value="Indonesia">Indonesia</option>
-                                            <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
-                                            <option value="Iraq">Iraq</option>
-                                            <option value="Ireland">Ireland</option>
-                                            <option value="Israel">Israel</option>
-                                            <option value="Italy">Italy</option>
-                                            <option value="Jamaica">Jamaica</option>
-                                            <option value="Japan">Japan</option>
-                                            <option value="Jordan">Jordan</option>
-                                            <option value="Kazakstan">Kazakstan</option>
-                                            <option value="Kenya">Kenya</option>
-                                            <option value="Kiribati">Kiribati</option>
-                                            <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
-                                            <option value="Korea, Republic of">Korea, Republic of</option>
-                                            <option value="Kuwait">Kuwait</option>
-                                            <option value="Kyrgyzstan">Kyrgyzstan</option>
-                                            <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
-                                            <option value="Latvia">Latvia</option>
-                                            <option value="Lebanon">Lebanon</option>
-                                            <option value="Lesotho">Lesotho</option>
-                                            <option value="Liberia">Liberia</option>
-                                            <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
-                                            <option value="Liechtenstein">Liechtenstein</option>
-                                            <option value="Lithuania">Lithuania</option>
-                                            <option value="Luxembourg">Luxembourg</option>
-                                            <option value="Macau">Macau</option>
-                                            <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
-                                            <option value="Madagascar">Madagascar</option>
-                                            <option value="Malawi">Malawi</option>
-                                            <option value="Malaysia">Malaysia</option>
-                                            <option value="Maldives">Maldives</option>
-                                            <option value="Mali">Mali</option>
-                                            <option value="Malta">Malta</option>
-                                            <option value="Marshall Islands">Marshall Islands</option>
-                                            <option value="Martinique">Martinique</option>
-                                            <option value="Mauritania">Mauritania</option>
-                                            <option value="Mauritius">Mauritius</option>
-                                            <option value="Mayotte">Mayotte</option>
-                                            <option value="Mexico">Mexico</option>
-                                            <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
-                                            <option value="Moldova, Republic of">Moldova, Republic of</option>
-                                            <option value="Monaco">Monaco</option>
-                                            <option value="Mongolia">Mongolia</option>
-                                            <option value="Montserrat">Montserrat</option>
-                                            <option value="Morocco">Morocco</option>
-                                            <option value="Mozambique">Mozambique</option>
-                                            <option value="Myanmar">Myanmar</option>
-                                            <option value="Namibia">Namibia</option>
-                                            <option value="Nauru">Nauru</option>
-                                            <option value="Nepal">Nepal</option>
-                                            <option value="Netherlands">Netherlands</option>
-                                            <option value="Netherlands Antilles">Netherlands Antilles</option>
-                                            <option value="New Caledonia">New Caledonia</option>
-                                            <option value="New Zealand">New Zealand</option>
-                                            <option value="Nicaragua">Nicaragua</option>
-                                            <option value="Niger">Niger</option>
-                                            <option value="Nigeria">Nigeria</option>
-                                            <option value="Niue">Niue</option>
-                                            <option value="Norfolk Island">Norfolk Island</option>
-                                            <option value="Northern Mariana Islands">Northern Mariana Islands</option>
-                                            <option value="Norway">Norway</option>
-                                            <option value="Oman">Oman</option>
-                                            <option value="Pakistan">Pakistan</option>
-                                            <option value="Palau">Palau</option>
-                                            <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
-                                            <option value="Panama">Panama</option>
-                                            <option value="Papua New Guinea">Papua New Guinea</option>
-                                            <option value="Paraguay">Paraguay</option>
-                                            <option value="Peru">Peru</option>
-                                            <option value="Philippines">Philippines</option>
-                                            <option value="Pitcairn">Pitcairn</option>
-                                            <option value="Poland">Poland</option>
-                                            <option value="Portugal">Portugal</option>
-                                            <option value="Puerto Rico">Puerto Rico</option>
-                                            <option value="Qatar">Qatar</option>
-                                            <option value="Reunion">Reunion</option>
-                                            <option value="Romania">Romania</option>
-                                            <option value="Russian Federation">Russian Federation</option>
-                                            <option value="Rwanda">Rwanda</option>
-                                            <option value="Saint Helena">Saint Helena</option>
-                                            <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
-                                            <option value="Saint Lucia">Saint Lucia</option>
-                                            <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
-                                            <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
-                                            <option value="Samoa">Samoa</option>
-                                            <option value="San Marino">San Marino</option>
-                                            <option value="Sao Tome and Principe">Sao Tome and Principe</option>
-                                            <option value="Saudi Arabia">Saudi Arabia</option>
-                                            <option value="Senegal">Senegal</option>
-                                            <option value="Seychelles">Seychelles</option>
-                                            <option value="Sierra Leone">Sierra Leone</option>
-                                            <option value="Singapore">Singapore</option>
-                                            <option value="Slovakia">Slovakia</option>
-                                            <option value="Slovenia">Slovenia</option>
-                                            <option value="Solomon Islands">Solomon Islands</option>
-                                            <option value="Somalia">Somalia</option>
-                                            <option value="South Africa">South Africa</option>
-                                            <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
-                                            <option value="Spain">Spain</option>
-                                            <option value="Sri Lanka">Sri Lanka</option>
-                                            <option value="Sudan">Sudan</option>
-                                            <option value="Suriname">Suriname</option>
-                                            <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
-                                            <option value="Swaziland">Swaziland</option>
-                                            <option value="Sweden">Sweden</option>
-                                            <option value="Switzerland">Switzerland</option>
-                                            <option value="Syrian Arab Republic">Syrian Arab Republic</option>
-                                            <option value="Taiwan">Taiwan</option>
-                                            <option value="Tajikistan">Tajikistan</option>
-                                            <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
-                                            <option value="Thailand">Thailand</option>
-                                            <option value="Togo">Togo</option>
-                                            <option value="Tokelau">Tokelau</option>
-                                            <option value="Tonga">Tonga</option>
-                                            <option value="Trinidad and Tobago">Trinidad and Tobago</option>
-                                            <option value="Tunisia">Tunisia</option>
-                                            <option value="Turkey">Turkey</option>
-                                            <option value="Turkmenistan">Turkmenistan</option>
-                                            <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
-                                            <option value="Tuvalu">Tuvalu</option>
-                                            <option value="Uganda">Uganda</option>
-                                            <option value="Ukraine">Ukraine</option>
-                                            <option value="United Arab Emirates">United Arab Emirates</option>
-                                            <option value="United Kingdom">United Kingdom</option>
-                                            <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
-                                            <option value="Uruguay">Uruguay</option>
-                                            <option value="Uzbekistan">Uzbekistan</option>
-                                            <option value="Vanuatu">Vanuatu</option>
-                                            <option value="Venezuela">Venezuela</option>
-                                            <option value="Viet Nam">Viet Nam</option>
-                                            <option value="Virgin Islands, British">Virgin Islands, British</option>
-                                            <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
-                                            <option value="Wallis and Futuna">Wallis and Futuna</option>
-                                            <option value="Western Sahara">Western Sahara</option>
-                                            <option value="Yemen">Yemen</option>
-                                            <option value="Yugoslavia">Yugoslavia</option>
-                                            <option value="Zambia">Zambia</option>
-                                            <option value="Zimbabwe">Zimbabwe</option>
-                                            <option value="Unknown">Unknown</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group form-group-md col-xs-6">
-                                        <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
-                                        <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
-                                            <option value="">Select</option>
-                                            <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
-                                            <option value="Trading As(TA)">Trading As(TA)</option>
-                                            <option value="Also Known As(AKA)">Also Known As(AKA)</option>
-                                            <option value="Formerly">Formerly</option>
-                                        </select>
-                                    </div>
-
-                                    <th:block  th:if="${owner.isAlternameSet() == true}">
-                                        <div class="form-group form-group-md col-xs-6" id="nametype">
-                                            <label for="nameoftype">Name</label>
-                                            <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
+    <div class="container-fluid">
+        <div class="row content"  style="display: none;">
+            <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
+                <div class="row" >
+                    <div class="col-xs-12">
+                        <!--START Content Div-->
+                        <div class="row">
+                            <section class="col-xs-12 steps breadcrumb-steps" aria-label="progress tracker">
+                                <div class="row displaycell">
+                                    <div class="col-xs-2 one" id="bs-header1">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>1</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link1">
+                                                <p class="first">Your details</p>
+                                            </div>
                                         </div>
-                                    </th:block>
-
-                                    <th:block  th:if="${owner.isAlternameSet() == false}">
-                                        <div class="form-group form-group-md col-xs-6" id="nametype" style="display: none;">
-                                            <label for="nameoftype">Name</label>
-                                            <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
+                                    </div>
+                                    <div class="col-xs-2 two" id="bs-header2">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>2</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link2">
+                                                <p>Trademark details</p>
+                                            </div>
                                         </div>
-                                    </th:block>
-
+                                    </div>
+                                    <div class="col-xs-2 three" id="bs-header3">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>3</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link3">
+                                                <p>Goods and services</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 four" id="bs-header4">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>4</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link4">
+                                                <p>Basis</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 five" id="bs-header5">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>5</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link5">
+                                                <p>Additional info</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 six" id="bs-header6">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>6</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link6">
+                                                <p>Confirm and pay</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </section>
+                        </div>
+                        <div class="row" style="">
+                            <div class="row">
+                                <div class="col-xs-6">
+                                    <h1 style="margin-left: 15px;">Edit Owner Information</h1>
 
                                 </div>
-                            </fieldset>
-                            <!--END Owner Information-->
-                            <!--START Sole Proprietor Information-->
-                            <div class="card-text">
-                                <h2 class="card-title weight600" id="proprietorinfo">General partner information</h2>
                             </div>
-                            <!--for each governing entity -->
-                            <!-- output section based on personEntity true false value -->
-                            <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity" style="">
-                                <th:block th:each="exceuter, iter : ${governingEntity}">
-                                    <div class="row">
-                                        <th:block th:if="${exceuter.isPrimaryGoverningEntity() == false}">
-                                            <div class="form-group form-group-md col-xs-12 removepartner">
-                                                <button type="button" class="btn btn-sm close removepartner" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
+                            <div class="col-xs-12 text-left">
+                                <!--START Owner Information Form-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="ownerinfo">Owner Information</h2>
+                                </div>
+                                <div id="partnerEntitydynamicFormArea">
+                                    <fieldset aria-labelledby="ownerinfo">
+                                        <div class="row">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
+                                                <input type="text" class="form-control"  id="ownername"  th:value="${owner.getOwnerName()}">
                                             </div>
-                                        </th:block>
-                                        <th:block th:if="${exceuter.isPersonEntity() == true}">
-                                            <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
-                                                <label ><span class="weight600">&#42;</span>First name</label>
-                                                <input type="text" name="firstName" class="form-control ge-first-name" th:value="${exceuter.firstName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}" >
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
-                                                <label >Middle name</label>
-                                                <input type="text" name="middleName" class="form-control ge-middle-name" th:value="${exceuter.middleName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
-                                                <label><span class="weight600">&#42;</span>Last name</label>
-                                                <input type="text" name="lastName" class="form-control ge-last-name" th:value="${exceuter.lastName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label>Suffix</label>
-                                                <input  class="form-control ge-suffix" name="suffix" />
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label><span class="weight600">&#42;</span>Country of citizenship</label>
-                                                <select class="form-control ge-citizenship" name="owner-citizenship" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
-                                                    <option th:value="${exceuter.entityCitizenship}"  th:text="${exceuter.entityCitizenship}" selected  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"></option>
+                                            <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                <label for="stateoforg">State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
+                                                <select class="form-control" id="stateoforg" th:field="${owner.ownerOrganizationState}" >
                                                     <option value="">Select</option>
                                                     <option value="United States of America">United States of America</option>
                                                     <option value="Afghanistan">Afghanistan</option>
@@ -649,17 +343,1023 @@
                                                     <option value="Unknown">Unknown</option>
                                                 </select>
                                             </div>
-                                        </th:block>
-
-                                        <th:block th:if="${exceuter.isPersonEntity() == false}">
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label><span class="weight600">&#42;</span>General partner name</label>
-                                                <input type="text" class="form-control rounded-borders ge-name"  style="" th:value="${exceuter.entityName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                                <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
+                                                    <option value="">Select</option>
+                                                    <option value="Doing Business As(DBA)">Doing Business As(DBA)</option>
+                                                    <option value="Trading As(TA)">Trading As(TA)</option>
+                                                    <option value="Also Known As(AKA)">Also Known As(AKA)</option>
+                                                    <option value="Formerly">Formerly</option>
+                                                </select>
                                             </div>
-                                            <div class="form-group form-group-md col-xs-6">
-                                                <label><span class="weight600">&#42;</span>State where legally organized</label>
-                                                <select class="form-control ge-state" name="State" th:attr="entity-index=${iter.index}" >
-                                                    <option th:value="${exceuter.organizationState}" th:text="${exceuter.organizationState}" th:attr="entity-id=${exceuter.id}"selected></option>
+
+                                            <th:block  th:if="${owner.isAlternameSet() == true}">
+                                                <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype">
+                                                    <label for="nameoftype">Name</label>
+                                                    <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
+                                                </div>
+                                            </th:block>
+
+                                            <th:block  th:if="${owner.isAlternameSet() == false}">
+                                                <div class="form-group form-group-md col-xs-12 col-sm-6 col-sm-6" id="nametype" style="display: none;">
+                                                    <label for="nameoftype">Name</label>
+                                                    <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
+                                                </div>
+                                            </th:block>
+
+
+                                        </div>
+                                    </fieldset>
+                                    <!--END Owner Information-->
+                                    <!--START Sole Proprietor Information-->
+                                    <div class="card-text">
+                                        <h2 class="card-title weight600" id="proprietorinfo">General partner information</h2>
+                                    </div>
+                                    <!--for each governing entity -->
+                                    <!-- output section based on personEntity true false value -->
+                                    <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity" style="">
+                                        <th:block th:each="exceuter, iter : ${governingEntity}">
+                                            <div class="row">
+                                                <th:block th:if="${exceuter.isPrimaryGoverningEntity() == false}">
+                                                    <div class="form-group form-group-md col-xs-12 removepartner">
+                                                        <button type="button" class="btn btn-sm close removepartner" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
+                                                    </div>
+                                                </th:block>
+                                                <th:block th:if="${exceuter.isPersonEntity() == true}">
+                                                    <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
+                                                        <label ><span class="weight600">&#42;</span>First name</label>
+                                                        <input type="text" name="firstName" class="form-control ge-first-name" th:value="${exceuter.firstName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}" >
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
+                                                        <label >Middle name</label>
+                                                        <input type="text" name="middleName" class="form-control ge-middle-name" th:value="${exceuter.middleName}"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
+                                                        <label><span class="weight600">&#42;</span>Last name</label>
+                                                        <input type="text" name="lastName" class="form-control ge-last-name" th:value="${exceuter.lastName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
+                                                        <label>Suffix</label>
+                                                        <input type="text" class="form-control ge-suffix" name="suffix" />
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
+                                                        <label>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                                        <select class="form-control ge-citizenship" name="owner-citizenship" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                            <option th:value="${exceuter.entityCitizenship}"  th:text="${exceuter.entityCitizenship}" selected  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"></option>
+                                                            <option value="">Select</option>
+                                                            <option value="United States of America">United States of America</option>
+                                                            <option value="Afghanistan">Afghanistan</option>
+                                                            <option value="Albania">Albania</option>
+                                                            <option value="Algeria">Algeria</option>
+                                                            <option value="American Samoa">American Samoa</option>
+                                                            <option value="Andorra">Andorra</option>
+                                                            <option value="Angola">Angola</option>
+                                                            <option value="Anguilla">Anguilla</option>
+                                                            <option value="Antarctica">Antarctica</option>
+                                                            <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+                                                            <option value="Argentina">Argentina</option>
+                                                            <option value="Armenia">Armenia</option>
+                                                            <option value="Aruba">Aruba</option>
+                                                            <option value="Australia">Australia</option>
+                                                            <option value="Austria">Austria</option>
+                                                            <option value="Azerbaijan">Azerbaijan</option>
+                                                            <option value="Bahamas">Bahamas</option>
+                                                            <option value="Bahrain">Bahrain</option>
+                                                            <option value="Bangladesh">Bangladesh</option>
+                                                            <option value="Barbados">Barbados</option>
+                                                            <option value="Belarus">Belarus</option>
+                                                            <option value="Belgium">Belgium</option>
+                                                            <option value="Belize">Belize</option>
+                                                            <option value="Benin">Benin</option>
+                                                            <option value="Bermuda">Bermuda</option>
+                                                            <option value="Bhutan">Bhutan</option>
+                                                            <option value="Bolivia">Bolivia</option>
+                                                            <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+                                                            <option value="Botswana">Botswana</option>
+                                                            <option value="Bouvet Island">Bouvet Island</option>
+                                                            <option value="Brazil">Brazil</option>
+                                                            <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+                                                            <option value="Brunei Darussalam">Brunei Darussalam</option>
+                                                            <option value="Bulgaria">Bulgaria</option>
+                                                            <option value="Burkina Faso">Burkina Faso</option>
+                                                            <option value="Burundi">Burundi</option>
+                                                            <option value="Canada">Canada</option>
+                                                            <option value="Cambodia">Cambodia</option>
+                                                            <option value="Cameroon">Cameroon</option>
+                                                            <option value="Cape Verde">Cape Verde</option>
+                                                            <option value="Cayman Islands">Cayman Islands</option>
+                                                            <option value="Central African Republic">Central African Republic</option>
+                                                            <option value="Chad">Chad</option>
+                                                            <option value="Chile">Chile</option>
+                                                            <option value="China">China</option>
+                                                            <option value="Christmas Island">Christmas Island</option>
+                                                            <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+                                                            <option value="Colombia">Colombia</option>
+                                                            <option value="Comoros">Comoros</option>
+                                                            <option value="Congo">Congo</option>
+                                                            <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
+                                                            <option value="Cook Islands">Cook Islands</option>
+                                                            <option value="Costa Rica">Costa Rica</option>
+                                                            <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
+                                                            <option value="Croatia">Croatia</option>
+                                                            <option value="Cuba">Cuba</option>
+                                                            <option value="Cyprus">Cyprus</option>
+                                                            <option value="Czech Republic">Czech Republic</option>
+                                                            <option value="Denmark">Denmark</option>
+                                                            <option value="Djibouti">Djibouti</option>
+                                                            <option value="Dominica">Dominica</option>
+                                                            <option value="Dominican Republic">Dominican Republic</option>
+                                                            <option value="East Timor">East Timor</option>
+                                                            <option value="Ecuador">Ecuador</option>
+                                                            <option value="Egypt">Egypt</option>
+                                                            <option value="El Salvador">El Salvador</option>
+                                                            <option value="Equatorial Guinea">Equatorial Guinea</option>
+                                                            <option value="Eritrea">Eritrea</option>
+                                                            <option value="Estonia">Estonia</option>
+                                                            <option value="Ethiopia">Ethiopia</option>
+                                                            <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+                                                            <option value="Faroe Islands">Faroe Islands</option>
+                                                            <option value="Fiji">Fiji</option>
+                                                            <option value="Finland">Finland</option>
+                                                            <option value="France">France</option>
+                                                            <option value="French Guiana">French Guiana</option>
+                                                            <option value="French Polynesia">French Polynesia</option>
+                                                            <option value="French Southern Territories">French Southern Territories</option>
+                                                            <option value="Gabon">Gabon</option>
+                                                            <option value="Gambia">Gambia</option>
+                                                            <option value="Georgia">Georgia</option>
+                                                            <option value="Germany">Germany</option>
+                                                            <option value="Ghana">Ghana</option>
+                                                            <option value="Gibraltar">Gibraltar</option>
+                                                            <option value="Greece">Greece</option>
+                                                            <option value="Greenland">Greenland</option>
+                                                            <option value="Grenada">Grenada</option>
+                                                            <option value="Guadeloupe">Guadeloupe</option>
+                                                            <option value="Guam">Guam</option>
+                                                            <option value="Guatemala">Guatemala</option>
+                                                            <option value="Guinea">Guinea</option>
+                                                            <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
+                                                            <option value="Guyana">Guyana</option>
+                                                            <option value="Haiti">Haiti</option>
+                                                            <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+                                                            <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+                                                            <option value="Honduras">Honduras</option>
+                                                            <option value="Hong Kong">Hong Kong</option>
+                                                            <option value="Hungary">Hungary</option>
+                                                            <option value="Iceland">Iceland</option>
+                                                            <option value="India">India</option>
+                                                            <option value="Indonesia">Indonesia</option>
+                                                            <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+                                                            <option value="Iraq">Iraq</option>
+                                                            <option value="Ireland">Ireland</option>
+                                                            <option value="Israel">Israel</option>
+                                                            <option value="Italy">Italy</option>
+                                                            <option value="Jamaica">Jamaica</option>
+                                                            <option value="Japan">Japan</option>
+                                                            <option value="Jordan">Jordan</option>
+                                                            <option value="Kazakstan">Kazakstan</option>
+                                                            <option value="Kenya">Kenya</option>
+                                                            <option value="Kiribati">Kiribati</option>
+                                                            <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
+                                                            <option value="Korea, Republic of">Korea, Republic of</option>
+                                                            <option value="Kuwait">Kuwait</option>
+                                                            <option value="Kyrgyzstan">Kyrgyzstan</option>
+                                                            <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
+                                                            <option value="Latvia">Latvia</option>
+                                                            <option value="Lebanon">Lebanon</option>
+                                                            <option value="Lesotho">Lesotho</option>
+                                                            <option value="Liberia">Liberia</option>
+                                                            <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
+                                                            <option value="Liechtenstein">Liechtenstein</option>
+                                                            <option value="Lithuania">Lithuania</option>
+                                                            <option value="Luxembourg">Luxembourg</option>
+                                                            <option value="Macau">Macau</option>
+                                                            <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
+                                                            <option value="Madagascar">Madagascar</option>
+                                                            <option value="Malawi">Malawi</option>
+                                                            <option value="Malaysia">Malaysia</option>
+                                                            <option value="Maldives">Maldives</option>
+                                                            <option value="Mali">Mali</option>
+                                                            <option value="Malta">Malta</option>
+                                                            <option value="Marshall Islands">Marshall Islands</option>
+                                                            <option value="Martinique">Martinique</option>
+                                                            <option value="Mauritania">Mauritania</option>
+                                                            <option value="Mauritius">Mauritius</option>
+                                                            <option value="Mayotte">Mayotte</option>
+                                                            <option value="Mexico">Mexico</option>
+                                                            <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+                                                            <option value="Moldova, Republic of">Moldova, Republic of</option>
+                                                            <option value="Monaco">Monaco</option>
+                                                            <option value="Mongolia">Mongolia</option>
+                                                            <option value="Montserrat">Montserrat</option>
+                                                            <option value="Morocco">Morocco</option>
+                                                            <option value="Mozambique">Mozambique</option>
+                                                            <option value="Myanmar">Myanmar</option>
+                                                            <option value="Namibia">Namibia</option>
+                                                            <option value="Nauru">Nauru</option>
+                                                            <option value="Nepal">Nepal</option>
+                                                            <option value="Netherlands">Netherlands</option>
+                                                            <option value="Netherlands Antilles">Netherlands Antilles</option>
+                                                            <option value="New Caledonia">New Caledonia</option>
+                                                            <option value="New Zealand">New Zealand</option>
+                                                            <option value="Nicaragua">Nicaragua</option>
+                                                            <option value="Niger">Niger</option>
+                                                            <option value="Nigeria">Nigeria</option>
+                                                            <option value="Niue">Niue</option>
+                                                            <option value="Norfolk Island">Norfolk Island</option>
+                                                            <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+                                                            <option value="Norway">Norway</option>
+                                                            <option value="Oman">Oman</option>
+                                                            <option value="Pakistan">Pakistan</option>
+                                                            <option value="Palau">Palau</option>
+                                                            <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+                                                            <option value="Panama">Panama</option>
+                                                            <option value="Papua New Guinea">Papua New Guinea</option>
+                                                            <option value="Paraguay">Paraguay</option>
+                                                            <option value="Peru">Peru</option>
+                                                            <option value="Philippines">Philippines</option>
+                                                            <option value="Pitcairn">Pitcairn</option>
+                                                            <option value="Poland">Poland</option>
+                                                            <option value="Portugal">Portugal</option>
+                                                            <option value="Puerto Rico">Puerto Rico</option>
+                                                            <option value="Qatar">Qatar</option>
+                                                            <option value="Reunion">Reunion</option>
+                                                            <option value="Romania">Romania</option>
+                                                            <option value="Russian Federation">Russian Federation</option>
+                                                            <option value="Rwanda">Rwanda</option>
+                                                            <option value="Saint Helena">Saint Helena</option>
+                                                            <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+                                                            <option value="Saint Lucia">Saint Lucia</option>
+                                                            <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+                                                            <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
+                                                            <option value="Samoa">Samoa</option>
+                                                            <option value="San Marino">San Marino</option>
+                                                            <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+                                                            <option value="Saudi Arabia">Saudi Arabia</option>
+                                                            <option value="Senegal">Senegal</option>
+                                                            <option value="Seychelles">Seychelles</option>
+                                                            <option value="Sierra Leone">Sierra Leone</option>
+                                                            <option value="Singapore">Singapore</option>
+                                                            <option value="Slovakia">Slovakia</option>
+                                                            <option value="Slovenia">Slovenia</option>
+                                                            <option value="Solomon Islands">Solomon Islands</option>
+                                                            <option value="Somalia">Somalia</option>
+                                                            <option value="South Africa">South Africa</option>
+                                                            <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
+                                                            <option value="Spain">Spain</option>
+                                                            <option value="Sri Lanka">Sri Lanka</option>
+                                                            <option value="Sudan">Sudan</option>
+                                                            <option value="Suriname">Suriname</option>
+                                                            <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+                                                            <option value="Swaziland">Swaziland</option>
+                                                            <option value="Sweden">Sweden</option>
+                                                            <option value="Switzerland">Switzerland</option>
+                                                            <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+                                                            <option value="Taiwan">Taiwan</option>
+                                                            <option value="Tajikistan">Tajikistan</option>
+                                                            <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+                                                            <option value="Thailand">Thailand</option>
+                                                            <option value="Togo">Togo</option>
+                                                            <option value="Tokelau">Tokelau</option>
+                                                            <option value="Tonga">Tonga</option>
+                                                            <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+                                                            <option value="Tunisia">Tunisia</option>
+                                                            <option value="Turkey">Turkey</option>
+                                                            <option value="Turkmenistan">Turkmenistan</option>
+                                                            <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+                                                            <option value="Tuvalu">Tuvalu</option>
+                                                            <option value="Uganda">Uganda</option>
+                                                            <option value="Ukraine">Ukraine</option>
+                                                            <option value="United Arab Emirates">United Arab Emirates</option>
+                                                            <option value="United Kingdom">United Kingdom</option>
+                                                            <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+                                                            <option value="Uruguay">Uruguay</option>
+                                                            <option value="Uzbekistan">Uzbekistan</option>
+                                                            <option value="Vanuatu">Vanuatu</option>
+                                                            <option value="Venezuela">Venezuela</option>
+                                                            <option value="Viet Nam">Viet Nam</option>
+                                                            <option value="Virgin Islands, British">Virgin Islands, British</option>
+                                                            <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+                                                            <option value="Wallis and Futuna">Wallis and Futuna</option>
+                                                            <option value="Western Sahara">Western Sahara</option>
+                                                            <option value="Yemen">Yemen</option>
+                                                            <option value="Yugoslavia">Yugoslavia</option>
+                                                            <option value="Zambia">Zambia</option>
+                                                            <option value="Zimbabwe">Zimbabwe</option>
+                                                            <option value="Unknown">Unknown</option>
+                                                        </select>
+                                                    </div>
+                                                </th:block>
+
+                                                <th:block th:if="${exceuter.isPersonEntity() == false}">
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                        <label><span class="weight600">&#42;</span>General partner name</label>
+                                                        <input type="text" class="form-control rounded-borders ge-name"  style="" th:value="${exceuter.entityName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                        <label>State where legally organized<span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                                        <select class="form-control ge-state" name="State" th:attr="entity-index=${iter.index}" >
+                                                            <option th:value="${exceuter.organizationState}" th:text="${exceuter.organizationState}" th:attr="entity-id=${exceuter.id}"selected></option>
+                                                            <option value="">Select</option>
+                                                            <option value="Alabama">Alabama</option>
+                                                            <option value="Alaska">Alaska</option>
+                                                            <option value="Arizona">Arizona</option>
+                                                            <option value="Arkansas">Arkansas</option>
+                                                            <option value="California">California</option>
+                                                            <option value="Colorado">Colorado</option>
+                                                            <option value="Connecticut">Connecticut</option>
+                                                            <option value="Delaware">Delaware</option>
+                                                            <option value="District of Columbia">District of Columbia</option>
+                                                            <option value="Florida">Florida</option>
+                                                            <option value="Georgia">Georgia</option>
+                                                            <option value="Hawaii">Hawaii</option>
+                                                            <option value="Idaho">Idaho</option>
+                                                            <option value="Illinois">Illinois</option>
+                                                            <option value="Indiana">Indiana</option>
+                                                            <option value="Iowa">Iowa</option>
+                                                            <option value="Kansas">Kansas</option>
+                                                            <option value="Kentucky">Kentucky</option>
+                                                            <option value="Louisiana">Louisiana</option>
+                                                            <option value="Maine">Maine</option>
+                                                            <option value="Maryland">Maryland</option>
+                                                            <option value="Massachusetts">Massachusetts</option>
+                                                            <option value="Michigan">Michigan</option>
+                                                            <option value="Minnesota">Minnesota</option>
+                                                            <option value="Mississippi">Mississippi</option>
+                                                            <option value="Missouri">Missouri</option>
+                                                            <option value="Montana">Montana</option>
+                                                            <option value="Nebraska">Nebraska</option>
+                                                            <option value="Nevada">Nevada</option>
+                                                            <option value="New Hampshire">New Hampshire</option>
+                                                            <option value="New Jersey">New Jersey</option>
+                                                            <option value="New Mexico">New Mexico</option>
+                                                            <option value="New York">New York</option>
+                                                            <option value="North Carolina">North Carolina</option>
+                                                            <option value="North Dakota">North Dakota</option>
+                                                            <option value="Ohio">Ohio</option>
+                                                            <option value="Oklahoma">Oklahoma</option>
+                                                            <option value="Oregon">Oregon</option>
+                                                            <option value="Pennsylvania">Pennsylvania</option>
+                                                            <option value="Rhode Island">Rhode Island</option>
+                                                            <option value="South Carolina">South Carolina</option>
+                                                            <option value="South Dakota">South Dakota</option>
+                                                            <option value="Tennessee">Tennessee</option>
+                                                            <option value="Texas">Texas</option>
+                                                            <option value="Utah">Utah</option>
+                                                            <option value="Vermont">Vermont</option>
+                                                            <option value="Virginia">Virginia</option>
+                                                            <option value="Washington">Washington</option>
+                                                            <option value="West Virginia">West Virginia</option>
+                                                            <option value="Wisconsin">Wisconsin</option>
+                                                            <option value="Wyoming">Wyoming</option>
+                                                        </select>
+                                                    </div>
+                                                </th:block>
+                                            </div>  <!--end of partner row from server  -->
+                                        </th:block>
+                                    </fieldset>
+                                    <div class="row">
+                                        <div class="col-xs-12 form-group form-group-md">
+                                        <div class="row addpartnership" style="display: none;">
+                                            <div class="form-group form-group-md col-xs-12 visuallyremoved resetpartner">
+                                                <button type="button" class="btn btn-sm close resetpartnerbtn" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
+                                            </div>
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                <label>Select entity type</label>
+                                                <span>
+                                                <select id="domestic-entity-dropdown-partner" class="form-control" name="nameType">
+                                                    <option id="opt-none" value="none"></option>
+                                                    <option id="opt-domestic-ind" value="Individual">Individual</option>
+                                                    <option id="opt-domestic-soleP" value="Sole Proprietorship" disabled>Sole Proprietorship</option>
+                                                    <option id="opt-domestic-llc" value="Limited Liability Company" disabled>Limited Liability Company</option>
+                                                    <option id="opt-domestic-part" value="Partnership" disabled>Partnership</option>
+                                                    <option id="opt-domestic-jvc" value="Joint Venture" disabled>Joint Venture</option>
+                                                    <option id="opt-domestic-trt" value="Trust" disabled>Trust</option>
+                                                    <option id="opt-domestic-est" value="Estate" disabled>Estate</option>
+                                                </select>
+                                            </span>
+                                            </div>
+                                            <div class="col-xs-12">
+                                                <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity-new" style="display: none;">
+                                                    <div class="row">
+                                                        <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
+                                                            <label><span class="weight600">&#42;</span>First name</label>
+                                                            <input type="text" class="form-control ge-first-name"  required value="">
+                                                        </div>
+                                                        <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
+                                                            <label >Middle name</label>
+                                                            <input type="text" class="form-control ge-middle-name"  value="">
+                                                        </div>
+                                                        <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
+                                                            <label ><span class="weight600">&#42;</span>Last name</label>
+                                                            <input  type="text"  class="form-control ge-last-name"  required value="">
+                                                        </div>
+                                                        <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
+                                                            <label for="partner-suffix">Suffix</label>
+                                                            <input type="text" class="form-control" id="partner-suffix"   value="">
+                                                        </div>
+                                                        <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
+                                                            <label>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                                            <select class="form-control ge-citizenship">
+                                                                <option value="">Select</option>
+                                                                <option value="United States of America">United States of America</option>
+                                                                <option value="Afghanistan">Afghanistan</option>
+                                                                <option value="Albania">Albania</option>
+                                                                <option value="Algeria">Algeria</option>
+                                                                <option value="American Samoa">American Samoa</option>
+                                                                <option value="Andorra">Andorra</option>
+                                                                <option value="Angola">Angola</option>
+                                                                <option value="Anguilla">Anguilla</option>
+                                                                <option value="Antarctica">Antarctica</option>
+                                                                <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+                                                                <option value="Argentina">Argentina</option>
+                                                                <option value="Armenia">Armenia</option>
+                                                                <option value="Aruba">Aruba</option>
+                                                                <option value="Australia">Australia</option>
+                                                                <option value="Austria">Austria</option>
+                                                                <option value="Azerbaijan">Azerbaijan</option>
+                                                                <option value="Bahamas">Bahamas</option>
+                                                                <option value="Bahrain">Bahrain</option>
+                                                                <option value="Bangladesh">Bangladesh</option>
+                                                                <option value="Barbados">Barbados</option>
+                                                                <option value="Belarus">Belarus</option>
+                                                                <option value="Belgium">Belgium</option>
+                                                                <option value="Belize">Belize</option>
+                                                                <option value="Benin">Benin</option>
+                                                                <option value="Bermuda">Bermuda</option>
+                                                                <option value="Bhutan">Bhutan</option>
+                                                                <option value="Bolivia">Bolivia</option>
+                                                                <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+                                                                <option value="Botswana">Botswana</option>
+                                                                <option value="Bouvet Island">Bouvet Island</option>
+                                                                <option value="Brazil">Brazil</option>
+                                                                <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+                                                                <option value="Brunei Darussalam">Brunei Darussalam</option>
+                                                                <option value="Bulgaria">Bulgaria</option>
+                                                                <option value="Burkina Faso">Burkina Faso</option>
+                                                                <option value="Burundi">Burundi</option>
+                                                                <option value="Canada">Canada</option>
+                                                                <option value="Cambodia">Cambodia</option>
+                                                                <option value="Cameroon">Cameroon</option>
+                                                                <option value="Cape Verde">Cape Verde</option>
+                                                                <option value="Cayman Islands">Cayman Islands</option>
+                                                                <option value="Central African Republic">Central African Republic</option>
+                                                                <option value="Chad">Chad</option>
+                                                                <option value="Chile">Chile</option>
+                                                                <option value="China">China</option>
+                                                                <option value="Christmas Island">Christmas Island</option>
+                                                                <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+                                                                <option value="Colombia">Colombia</option>
+                                                                <option value="Comoros">Comoros</option>
+                                                                <option value="Congo">Congo</option>
+                                                                <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
+                                                                <option value="Cook Islands">Cook Islands</option>
+                                                                <option value="Costa Rica">Costa Rica</option>
+                                                                <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
+                                                                <option value="Croatia">Croatia</option>
+                                                                <option value="Cuba">Cuba</option>
+                                                                <option value="Cyprus">Cyprus</option>
+                                                                <option value="Czech Republic">Czech Republic</option>
+                                                                <option value="Denmark">Denmark</option>
+                                                                <option value="Djibouti">Djibouti</option>
+                                                                <option value="Dominica">Dominica</option>
+                                                                <option value="Dominican Republic">Dominican Republic</option>
+                                                                <option value="East Timor">East Timor</option>
+                                                                <option value="Ecuador">Ecuador</option>
+                                                                <option value="Egypt">Egypt</option>
+                                                                <option value="El Salvador">El Salvador</option>
+                                                                <option value="Equatorial Guinea">Equatorial Guinea</option>
+                                                                <option value="Eritrea">Eritrea</option>
+                                                                <option value="Estonia">Estonia</option>
+                                                                <option value="Ethiopia">Ethiopia</option>
+                                                                <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+                                                                <option value="Faroe Islands">Faroe Islands</option>
+                                                                <option value="Fiji">Fiji</option>
+                                                                <option value="Finland">Finland</option>
+                                                                <option value="France">France</option>
+                                                                <option value="French Guiana">French Guiana</option>
+                                                                <option value="French Polynesia">French Polynesia</option>
+                                                                <option value="French Southern Territories">French Southern Territories</option>
+                                                                <option value="Gabon">Gabon</option>
+                                                                <option value="Gambia">Gambia</option>
+                                                                <option value="Georgia">Georgia</option>
+                                                                <option value="Germany">Germany</option>
+                                                                <option value="Ghana">Ghana</option>
+                                                                <option value="Gibraltar">Gibraltar</option>
+                                                                <option value="Greece">Greece</option>
+                                                                <option value="Greenland">Greenland</option>
+                                                                <option value="Grenada">Grenada</option>
+                                                                <option value="Guadeloupe">Guadeloupe</option>
+                                                                <option value="Guam">Guam</option>
+                                                                <option value="Guatemala">Guatemala</option>
+                                                                <option value="Guinea">Guinea</option>
+                                                                <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
+                                                                <option value="Guyana">Guyana</option>
+                                                                <option value="Haiti">Haiti</option>
+                                                                <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+                                                                <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+                                                                <option value="Honduras">Honduras</option>
+                                                                <option value="Hong Kong">Hong Kong</option>
+                                                                <option value="Hungary">Hungary</option>
+                                                                <option value="Iceland">Iceland</option>
+                                                                <option value="India">India</option>
+                                                                <option value="Indonesia">Indonesia</option>
+                                                                <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+                                                                <option value="Iraq">Iraq</option>
+                                                                <option value="Ireland">Ireland</option>
+                                                                <option value="Israel">Israel</option>
+                                                                <option value="Italy">Italy</option>
+                                                                <option value="Jamaica">Jamaica</option>
+                                                                <option value="Japan">Japan</option>
+                                                                <option value="Jordan">Jordan</option>
+                                                                <option value="Kazakstan">Kazakstan</option>
+                                                                <option value="Kenya">Kenya</option>
+                                                                <option value="Kiribati">Kiribati</option>
+                                                                <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
+                                                                <option value="Korea, Republic of">Korea, Republic of</option>
+                                                                <option value="Kuwait">Kuwait</option>
+                                                                <option value="Kyrgyzstan">Kyrgyzstan</option>
+                                                                <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
+                                                                <option value="Latvia">Latvia</option>
+                                                                <option value="Lebanon">Lebanon</option>
+                                                                <option value="Lesotho">Lesotho</option>
+                                                                <option value="Liberia">Liberia</option>
+                                                                <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
+                                                                <option value="Liechtenstein">Liechtenstein</option>
+                                                                <option value="Lithuania">Lithuania</option>
+                                                                <option value="Luxembourg">Luxembourg</option>
+                                                                <option value="Macau">Macau</option>
+                                                                <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
+                                                                <option value="Madagascar">Madagascar</option>
+                                                                <option value="Malawi">Malawi</option>
+                                                                <option value="Malaysia">Malaysia</option>
+                                                                <option value="Maldives">Maldives</option>
+                                                                <option value="Mali">Mali</option>
+                                                                <option value="Malta">Malta</option>
+                                                                <option value="Marshall Islands">Marshall Islands</option>
+                                                                <option value="Martinique">Martinique</option>
+                                                                <option value="Mauritania">Mauritania</option>
+                                                                <option value="Mauritius">Mauritius</option>
+                                                                <option value="Mayotte">Mayotte</option>
+                                                                <option value="Mexico">Mexico</option>
+                                                                <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+                                                                <option value="Moldova, Republic of">Moldova, Republic of</option>
+                                                                <option value="Monaco">Monaco</option>
+                                                                <option value="Mongolia">Mongolia</option>
+                                                                <option value="Montserrat">Montserrat</option>
+                                                                <option value="Morocco">Morocco</option>
+                                                                <option value="Mozambique">Mozambique</option>
+                                                                <option value="Myanmar">Myanmar</option>
+                                                                <option value="Namibia">Namibia</option>
+                                                                <option value="Nauru">Nauru</option>
+                                                                <option value="Nepal">Nepal</option>
+                                                                <option value="Netherlands">Netherlands</option>
+                                                                <option value="Netherlands Antilles">Netherlands Antilles</option>
+                                                                <option value="New Caledonia">New Caledonia</option>
+                                                                <option value="New Zealand">New Zealand</option>
+                                                                <option value="Nicaragua">Nicaragua</option>
+                                                                <option value="Niger">Niger</option>
+                                                                <option value="Nigeria">Nigeria</option>
+                                                                <option value="Niue">Niue</option>
+                                                                <option value="Norfolk Island">Norfolk Island</option>
+                                                                <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+                                                                <option value="Norway">Norway</option>
+                                                                <option value="Oman">Oman</option>
+                                                                <option value="Pakistan">Pakistan</option>
+                                                                <option value="Palau">Palau</option>
+                                                                <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+                                                                <option value="Panama">Panama</option>
+                                                                <option value="Papua New Guinea">Papua New Guinea</option>
+                                                                <option value="Paraguay">Paraguay</option>
+                                                                <option value="Peru">Peru</option>
+                                                                <option value="Philippines">Philippines</option>
+                                                                <option value="Pitcairn">Pitcairn</option>
+                                                                <option value="Poland">Poland</option>
+                                                                <option value="Portugal">Portugal</option>
+                                                                <option value="Puerto Rico">Puerto Rico</option>
+                                                                <option value="Qatar">Qatar</option>
+                                                                <option value="Reunion">Reunion</option>
+                                                                <option value="Romania">Romania</option>
+                                                                <option value="Russian Federation">Russian Federation</option>
+                                                                <option value="Rwanda">Rwanda</option>
+                                                                <option value="Saint Helena">Saint Helena</option>
+                                                                <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+                                                                <option value="Saint Lucia">Saint Lucia</option>
+                                                                <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+                                                                <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
+                                                                <option value="Samoa">Samoa</option>
+                                                                <option value="San Marino">San Marino</option>
+                                                                <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+                                                                <option value="Saudi Arabia">Saudi Arabia</option>
+                                                                <option value="Senegal">Senegal</option>
+                                                                <option value="Seychelles">Seychelles</option>
+                                                                <option value="Sierra Leone">Sierra Leone</option>
+                                                                <option value="Singapore">Singapore</option>
+                                                                <option value="Slovakia">Slovakia</option>
+                                                                <option value="Slovenia">Slovenia</option>
+                                                                <option value="Solomon Islands">Solomon Islands</option>
+                                                                <option value="Somalia">Somalia</option>
+                                                                <option value="South Africa">South Africa</option>
+                                                                <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
+                                                                <option value="Spain">Spain</option>
+                                                                <option value="Sri Lanka">Sri Lanka</option>
+                                                                <option value="Sudan">Sudan</option>
+                                                                <option value="Suriname">Suriname</option>
+                                                                <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+                                                                <option value="Swaziland">Swaziland</option>
+                                                                <option value="Sweden">Sweden</option>
+                                                                <option value="Switzerland">Switzerland</option>
+                                                                <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+                                                                <option value="Taiwan">Taiwan</option>
+                                                                <option value="Tajikistan">Tajikistan</option>
+                                                                <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+                                                                <option value="Thailand">Thailand</option>
+                                                                <option value="Togo">Togo</option>
+                                                                <option value="Tokelau">Tokelau</option>
+                                                                <option value="Tonga">Tonga</option>
+                                                                <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+                                                                <option value="Tunisia">Tunisia</option>
+                                                                <option value="Turkey">Turkey</option>
+                                                                <option value="Turkmenistan">Turkmenistan</option>
+                                                                <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+                                                                <option value="Tuvalu">Tuvalu</option>
+                                                                <option value="Uganda">Uganda</option>
+                                                                <option value="Ukraine">Ukraine</option>
+                                                                <option value="United Arab Emirates">United Arab Emirates</option>
+                                                                <option value="United Kingdom">United Kingdom</option>
+                                                                <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+                                                                <option value="Uruguay">Uruguay</option>
+                                                                <option value="Uzbekistan">Uzbekistan</option>
+                                                                <option value="Vanuatu">Vanuatu</option>
+                                                                <option value="Venezuela">Venezuela</option>
+                                                                <option value="Viet Nam">Viet Nam</option>
+                                                                <option value="Virgin Islands, British">Virgin Islands, British</option>
+                                                                <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+                                                                <option value="Wallis and Futuna">Wallis and Futuna</option>
+                                                                <option value="Western Sahara">Western Sahara</option>
+                                                                <option value="Yemen">Yemen</option>
+                                                                <option value="Yugoslavia">Yugoslavia</option>
+                                                                <option value="Zambia">Zambia</option>
+                                                                <option value="Zimbabwe">Zimbabwe</option>
+                                                                <option value="Unknown">Unknown</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                </fieldset>
+                                                <fieldset aria-labelledby="proprietorinfo" id="none-individual-partner-entity-new" style="display: none;">
+                                                    <div class="row">
+                                                        <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                            <label for="ownername"><span class="weight600">&#42;</span>General partner name</label>
+                                                            <input type="text" class="form-control rounded-borders ge-name"  required  value="">
+                                                        </div>
+                                                        <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                                            <label>State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
+                                                            <select class="form-control ge-state">
+                                                                <option value="">Select</option>
+                                                                <option value="Alabama">Alabama</option>
+                                                                <option value="Alaska">Alaska</option>
+                                                                <option value="Arizona">Arizona</option>
+                                                                <option value="Arkansas">Arkansas</option>
+                                                                <option value="California">California</option>
+                                                                <option value="Colorado">Colorado</option>
+                                                                <option value="Connecticut">Connecticut</option>
+                                                                <option value="Delaware">Delaware</option>
+                                                                <option value="District of Columbia">District of Columbia</option>
+                                                                <option value="Florida">Florida</option>
+                                                                <option value="Georgia">Georgia</option>
+                                                                <option value="Hawaii">Hawaii</option>
+                                                                <option value="Idaho">Idaho</option>
+                                                                <option value="Illinois">Illinois</option>
+                                                                <option value="Indiana">Indiana</option>
+                                                                <option value="Iowa">Iowa</option>
+                                                                <option value="Kansas">Kansas</option>
+                                                                <option value="Kentucky">Kentucky</option>
+                                                                <option value="Louisiana">Louisiana</option>
+                                                                <option value="Maine">Maine</option>
+                                                                <option value="Maryland">Maryland</option>
+                                                                <option value="Massachusetts">Massachusetts</option>
+                                                                <option value="Michigan">Michigan</option>
+                                                                <option value="Minnesota">Minnesota</option>
+                                                                <option value="Mississippi">Mississippi</option>
+                                                                <option value="Missouri">Missouri</option>
+                                                                <option value="Montana">Montana</option>
+                                                                <option value="Nebraska">Nebraska</option>
+                                                                <option value="Nevada">Nevada</option>
+                                                                <option value="New Hampshire">New Hampshire</option>
+                                                                <option value="New Jersey">New Jersey</option>
+                                                                <option value="New Mexico">New Mexico</option>
+                                                                <option value="New York">New York</option>
+                                                                <option value="North Carolina">North Carolina</option>
+                                                                <option value="North Dakota">North Dakota</option>
+                                                                <option value="Ohio">Ohio</option>
+                                                                <option value="Oklahoma">Oklahoma</option>
+                                                                <option value="Oregon">Oregon</option>
+                                                                <option value="Pennsylvania">Pennsylvania</option>
+                                                                <option value="Rhode Island">Rhode Island</option>
+                                                                <option value="South Carolina">South Carolina</option>
+                                                                <option value="South Dakota">South Dakota</option>
+                                                                <option value="Tennessee">Tennessee</option>
+                                                                <option value="Texas">Texas</option>
+                                                                <option value="Utah">Utah</option>
+                                                                <option value="Vermont">Vermont</option>
+                                                                <option value="Virginia">Virginia</option>
+                                                                <option value="Washington">Washington</option>
+                                                                <option value="West Virginia">West Virginia</option>
+                                                                <option value="Wisconsin">Wisconsin</option>
+                                                                <option value="Wyoming">Wyoming</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                </fieldset>
+                                            </div> <!-- end of arrary dto object -->
+                                        </div>
+                                    </div>
+                                    </div>
+                                    <!--END hidden content-->
+                                    <div class="appendpartner col-xs-12"></div>
+                                    <div class="row" id="hideshow_addpartner">
+
+                                        <div class="col-xs-12 form-group form-group-md" aria-label="add a partner">
+                                            <div class="inlinebuttons btn-group btn-group-justified">
+                                                <div class="btn-group col-xs-6">
+                                                    <button type="button" class="btn btn-sm btn-success addinitial" id="addpartner">Add Partner</button>
+                                                </div>
+                                            </div>
+                                        </div><!--// add button-->
+                                    </div><!--// hide / show add partner-->
+                                    <!--END Sole Proprietor Information Form-->
+                                    <!--START Owner Address Information Form-->
+                                    <div class="card-text">
+                                        <h2 class="card-title weight600" id="addressinfo">Owner Address Information</h2>
+                                    </div>
+                                    <fieldset aria-labelledby="addressinfo">
+                                        <div class="row">
+                                            <div class="form-group form-group-md col-md-12 col-lg-7">
+                                                <label for="OwnerAddressCountry"><span class="weight600">&#42;</span>Country / U.S. territory</label>
+                                                <select class="form-control" id="OwnerAddressCountry" name="territory" th:field="${owner.country}" >
+                                                    <option value="">Select</option>
+                                                    <option value="United States of America">United States of America</option>
+                                                    <option value="Afghanistan">Afghanistan</option>
+                                                    <option value="Albania">Albania</option>
+                                                    <option value="Algeria">Algeria</option>
+                                                    <option value="American Samoa">American Samoa</option>
+                                                    <option value="Andorra">Andorra</option>
+                                                    <option value="Angola">Angola</option>
+                                                    <option value="Anguilla">Anguilla</option>
+                                                    <option value="Antarctica">Antarctica</option>
+                                                    <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+                                                    <option value="Argentina">Argentina</option>
+                                                    <option value="Armenia">Armenia</option>
+                                                    <option value="Aruba">Aruba</option>
+                                                    <option value="Australia">Australia</option>
+                                                    <option value="Austria">Austria</option>
+                                                    <option value="Azerbaijan">Azerbaijan</option>
+                                                    <option value="Bahamas">Bahamas</option>
+                                                    <option value="Bahrain">Bahrain</option>
+                                                    <option value="Bangladesh">Bangladesh</option>
+                                                    <option value="Barbados">Barbados</option>
+                                                    <option value="Belarus">Belarus</option>
+                                                    <option value="Belgium">Belgium</option>
+                                                    <option value="Belize">Belize</option>
+                                                    <option value="Benin">Benin</option>
+                                                    <option value="Bermuda">Bermuda</option>
+                                                    <option value="Bhutan">Bhutan</option>
+                                                    <option value="Bolivia">Bolivia</option>
+                                                    <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+                                                    <option value="Botswana">Botswana</option>
+                                                    <option value="Bouvet Island">Bouvet Island</option>
+                                                    <option value="Brazil">Brazil</option>
+                                                    <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+                                                    <option value="Brunei Darussalam">Brunei Darussalam</option>
+                                                    <option value="Bulgaria">Bulgaria</option>
+                                                    <option value="Burkina Faso">Burkina Faso</option>
+                                                    <option value="Burundi">Burundi</option>
+                                                    <option value="Canada">Canada</option>
+                                                    <option value="Cambodia">Cambodia</option>
+                                                    <option value="Cameroon">Cameroon</option>
+                                                    <option value="Cape Verde">Cape Verde</option>
+                                                    <option value="Cayman Islands">Cayman Islands</option>
+                                                    <option value="Central African Republic">Central African Republic</option>
+                                                    <option value="Chad">Chad</option>
+                                                    <option value="Chile">Chile</option>
+                                                    <option value="China">China</option>
+                                                    <option value="Christmas Island">Christmas Island</option>
+                                                    <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+                                                    <option value="Colombia">Colombia</option>
+                                                    <option value="Comoros">Comoros</option>
+                                                    <option value="Congo">Congo</option>
+                                                    <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
+                                                    <option value="Cook Islands">Cook Islands</option>
+                                                    <option value="Costa Rica">Costa Rica</option>
+                                                    <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
+                                                    <option value="Croatia">Croatia</option>
+                                                    <option value="Cuba">Cuba</option>
+                                                    <option value="Cyprus">Cyprus</option>
+                                                    <option value="Czech Republic">Czech Republic</option>
+                                                    <option value="Denmark">Denmark</option>
+                                                    <option value="Djibouti">Djibouti</option>
+                                                    <option value="Dominica">Dominica</option>
+                                                    <option value="Dominican Republic">Dominican Republic</option>
+                                                    <option value="East Timor">East Timor</option>
+                                                    <option value="Ecuador">Ecuador</option>
+                                                    <option value="Egypt">Egypt</option>
+                                                    <option value="El Salvador">El Salvador</option>
+                                                    <option value="Equatorial Guinea">Equatorial Guinea</option>
+                                                    <option value="Eritrea">Eritrea</option>
+                                                    <option value="Estonia">Estonia</option>
+                                                    <option value="Ethiopia">Ethiopia</option>
+                                                    <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+                                                    <option value="Faroe Islands">Faroe Islands</option>
+                                                    <option value="Fiji">Fiji</option>
+                                                    <option value="Finland">Finland</option>
+                                                    <option value="France">France</option>
+                                                    <option value="French Guiana">French Guiana</option>
+                                                    <option value="French Polynesia">French Polynesia</option>
+                                                    <option value="French Southern Territories">French Southern Territories</option>
+                                                    <option value="Gabon">Gabon</option>
+                                                    <option value="Gambia">Gambia</option>
+                                                    <option value="Georgia">Georgia</option>
+                                                    <option value="Germany">Germany</option>
+                                                    <option value="Ghana">Ghana</option>
+                                                    <option value="Gibraltar">Gibraltar</option>
+                                                    <option value="Greece">Greece</option>
+                                                    <option value="Greenland">Greenland</option>
+                                                    <option value="Grenada">Grenada</option>
+                                                    <option value="Guadeloupe">Guadeloupe</option>
+                                                    <option value="Guam">Guam</option>
+                                                    <option value="Guatemala">Guatemala</option>
+                                                    <option value="Guinea">Guinea</option>
+                                                    <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
+                                                    <option value="Guyana">Guyana</option>
+                                                    <option value="Haiti">Haiti</option>
+                                                    <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+                                                    <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+                                                    <option value="Honduras">Honduras</option>
+                                                    <option value="Hong Kong">Hong Kong</option>
+                                                    <option value="Hungary">Hungary</option>
+                                                    <option value="Iceland">Iceland</option>
+                                                    <option value="India">India</option>
+                                                    <option value="Indonesia">Indonesia</option>
+                                                    <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+                                                    <option value="Iraq">Iraq</option>
+                                                    <option value="Ireland">Ireland</option>
+                                                    <option value="Israel">Israel</option>
+                                                    <option value="Italy">Italy</option>
+                                                    <option value="Jamaica">Jamaica</option>
+                                                    <option value="Japan">Japan</option>
+                                                    <option value="Jordan">Jordan</option>
+                                                    <option value="Kazakstan">Kazakstan</option>
+                                                    <option value="Kenya">Kenya</option>
+                                                    <option value="Kiribati">Kiribati</option>
+                                                    <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
+                                                    <option value="Korea, Republic of">Korea, Republic of</option>
+                                                    <option value="Kuwait">Kuwait</option>
+                                                    <option value="Kyrgyzstan">Kyrgyzstan</option>
+                                                    <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
+                                                    <option value="Latvia">Latvia</option>
+                                                    <option value="Lebanon">Lebanon</option>
+                                                    <option value="Lesotho">Lesotho</option>
+                                                    <option value="Liberia">Liberia</option>
+                                                    <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
+                                                    <option value="Liechtenstein">Liechtenstein</option>
+                                                    <option value="Lithuania">Lithuania</option>
+                                                    <option value="Luxembourg">Luxembourg</option>
+                                                    <option value="Macau">Macau</option>
+                                                    <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
+                                                    <option value="Madagascar">Madagascar</option>
+                                                    <option value="Malawi">Malawi</option>
+                                                    <option value="Malaysia">Malaysia</option>
+                                                    <option value="Maldives">Maldives</option>
+                                                    <option value="Mali">Mali</option>
+                                                    <option value="Malta">Malta</option>
+                                                    <option value="Marshall Islands">Marshall Islands</option>
+                                                    <option value="Martinique">Martinique</option>
+                                                    <option value="Mauritania">Mauritania</option>
+                                                    <option value="Mauritius">Mauritius</option>
+                                                    <option value="Mayotte">Mayotte</option>
+                                                    <option value="Mexico">Mexico</option>
+                                                    <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+                                                    <option value="Moldova, Republic of">Moldova, Republic of</option>
+                                                    <option value="Monaco">Monaco</option>
+                                                    <option value="Mongolia">Mongolia</option>
+                                                    <option value="Montserrat">Montserrat</option>
+                                                    <option value="Morocco">Morocco</option>
+                                                    <option value="Mozambique">Mozambique</option>
+                                                    <option value="Myanmar">Myanmar</option>
+                                                    <option value="Namibia">Namibia</option>
+                                                    <option value="Nauru">Nauru</option>
+                                                    <option value="Nepal">Nepal</option>
+                                                    <option value="Netherlands">Netherlands</option>
+                                                    <option value="Netherlands Antilles">Netherlands Antilles</option>
+                                                    <option value="New Caledonia">New Caledonia</option>
+                                                    <option value="New Zealand">New Zealand</option>
+                                                    <option value="Nicaragua">Nicaragua</option>
+                                                    <option value="Niger">Niger</option>
+                                                    <option value="Nigeria">Nigeria</option>
+                                                    <option value="Niue">Niue</option>
+                                                    <option value="Norfolk Island">Norfolk Island</option>
+                                                    <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+                                                    <option value="Norway">Norway</option>
+                                                    <option value="Oman">Oman</option>
+                                                    <option value="Pakistan">Pakistan</option>
+                                                    <option value="Palau">Palau</option>
+                                                    <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+                                                    <option value="Panama">Panama</option>
+                                                    <option value="Papua New Guinea">Papua New Guinea</option>
+                                                    <option value="Paraguay">Paraguay</option>
+                                                    <option value="Peru">Peru</option>
+                                                    <option value="Philippines">Philippines</option>
+                                                    <option value="Pitcairn">Pitcairn</option>
+                                                    <option value="Poland">Poland</option>
+                                                    <option value="Portugal">Portugal</option>
+                                                    <option value="Puerto Rico">Puerto Rico</option>
+                                                    <option value="Qatar">Qatar</option>
+                                                    <option value="Reunion">Reunion</option>
+                                                    <option value="Romania">Romania</option>
+                                                    <option value="Russian Federation">Russian Federation</option>
+                                                    <option value="Rwanda">Rwanda</option>
+                                                    <option value="Saint Helena">Saint Helena</option>
+                                                    <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+                                                    <option value="Saint Lucia">Saint Lucia</option>
+                                                    <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+                                                    <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
+                                                    <option value="Samoa">Samoa</option>
+                                                    <option value="San Marino">San Marino</option>
+                                                    <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+                                                    <option value="Saudi Arabia">Saudi Arabia</option>
+                                                    <option value="Senegal">Senegal</option>
+                                                    <option value="Seychelles">Seychelles</option>
+                                                    <option value="Sierra Leone">Sierra Leone</option>
+                                                    <option value="Singapore">Singapore</option>
+                                                    <option value="Slovakia">Slovakia</option>
+                                                    <option value="Slovenia">Slovenia</option>
+                                                    <option value="Solomon Islands">Solomon Islands</option>
+                                                    <option value="Somalia">Somalia</option>
+                                                    <option value="South Africa">South Africa</option>
+                                                    <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
+                                                    <option value="Spain">Spain</option>
+                                                    <option value="Sri Lanka">Sri Lanka</option>
+                                                    <option value="Sudan">Sudan</option>
+                                                    <option value="Suriname">Suriname</option>
+                                                    <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+                                                    <option value="Swaziland">Swaziland</option>
+                                                    <option value="Sweden">Sweden</option>
+                                                    <option value="Switzerland">Switzerland</option>
+                                                    <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+                                                    <option value="Taiwan">Taiwan</option>
+                                                    <option value="Tajikistan">Tajikistan</option>
+                                                    <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+                                                    <option value="Thailand">Thailand</option>
+                                                    <option value="Togo">Togo</option>
+                                                    <option value="Tokelau">Tokelau</option>
+                                                    <option value="Tonga">Tonga</option>
+                                                    <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+                                                    <option value="Tunisia">Tunisia</option>
+                                                    <option value="Turkey">Turkey</option>
+                                                    <option value="Turkmenistan">Turkmenistan</option>
+                                                    <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+                                                    <option value="Tuvalu">Tuvalu</option>
+                                                    <option value="Uganda">Uganda</option>
+                                                    <option value="Ukraine">Ukraine</option>
+                                                    <option value="United Arab Emirates">United Arab Emirates</option>
+                                                    <option value="United Kingdom">United Kingdom</option>
+                                                    <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+                                                    <option value="Uruguay">Uruguay</option>
+                                                    <option value="Uzbekistan">Uzbekistan</option>
+                                                    <option value="Vanuatu">Vanuatu</option>
+                                                    <option value="Venezuela">Venezuela</option>
+                                                    <option value="Viet Nam">Viet Nam</option>
+                                                    <option value="Virgin Islands, British">Virgin Islands, British</option>
+                                                    <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+                                                    <option value="Wallis and Futuna">Wallis and Futuna</option>
+                                                    <option value="Western Sahara">Western Sahara</option>
+                                                    <option value="Yemen">Yemen</option>
+                                                    <option value="Yugoslavia">Yugoslavia</option>
+                                                    <option value="Zambia">Zambia</option>
+                                                    <option value="Zimbabwe">Zimbabwe</option>
+                                                    <option value="Unknown">Unknown</option>
+                                                </select>
+                                            </div>
+                                            <div class="form-group form-group-md col-md-12 col-lg-9">
+                                                <label for="ownerAddress1"><span class="weight600">&#42;</span>Address line 1</label>
+                                                <input type="text" class="form-control" id="ownerAddress1" th:value="${owner.address1}" >
+                                            </div>
+                                            <div class="form-group form-group-md col-md-12 col-lg-9">
+                                                <label for="addressline2">Address line 2</label>
+                                                <input type="text" class="form-control" id="addressline2" >
+                                            </div>
+                                            <div class="form-group form-group-md col-md-12 col-lg-9">
+                                                <label for="addressline3">Address line 3</label>
+                                                <input type="text" class="form-control" id="addressline3" >
+                                            </div>
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
+                                                <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}">
+                                            </div>
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                                <label for="ownerState"><span class="weight600">&#42;</span>State/Province/Territory</label>
+                                                <select class="form-control" id="ownerState" th:field="${owner.state}" required>
                                                     <option value="">Select</option>
                                                     <option value="Alabama">Alabama</option>
                                                     <option value="Alaska">Alaska</option>
@@ -714,767 +1414,70 @@
                                                     <option value="Wyoming">Wyoming</option>
                                                 </select>
                                             </div>
-                                        </th:block>
-                                    </div>  <!--end of partner row from server  -->
-                                </th:block>
-                            </fieldset>
-                            <div class="col-xs-12 form-group form-group-md">
-                                <div class="row addpartnership" style="display: none;">
-                                    <div class="form-group form-group-md col-xs-12 visuallyremoved resetpartner">
-                                        <button type="button" class="btn btn-sm close resetpartnerbtn" aria-label="remove this partner"><span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span></button>
-                                    </div>
-                                    <div class="col-xs-12 form-group form-group-md">
-                                        <label>Select entity type</label>
-                                        <span>
-                                        <select id="domestic-entity-dropdown-partner" class="form-control" name="nameType">
-                                            <option id="opt-none" value="none"></option>
-                                            <option id="opt-domestic-ind" value="Individual">Individual</option>
-                                            <option id="opt-domestic-soleP" value="Sole Proprietorship" disabled>Sole Proprietorship</option>
-                                            <option id="opt-domestic-llc" value="Limited Liability Company" disabled>Limited Liability Company</option>
-                                            <option id="opt-domestic-part" value="Partnership" disabled>Partnership</option>
-                                            <option id="opt-domestic-jvc" value="Joint Venture" disabled>Joint Venture</option>
-                                            <option id="opt-domestic-trt" value="Trust" disabled>Trust</option>
-                                            <option id="opt-domestic-est" value="Estate" disabled>Estate</option>
-                                        </select>
-                                    </span>
-                                    </div>
-                                    <div class="col-xs-12">
-                                        <fieldset aria-labelledby="proprietorinfo" id="individual-partner-entity-new" style="display: none;">
-                                            <div class="row">
-                                                <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
-                                                    <label><span class="weight600">&#42;</span>First name</label>
-                                                    <input type="text"   class="form-control ge-first-name"  required value="">
-                                                </div>
-                                                <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
-                                                    <label >Middle name</label>
-                                                    <input type="text" class="form-control ge-middle-name"  value="">
-                                                </div>
-                                                <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
-                                                    <label ><span class="weight600">&#42;</span>Last name</label>
-                                                    <input  type="text"  class="form-control ge-last-name"  required value="">
-                                                </div>
-                                                <div class="form-group form-group-md col-xs-6">
-                                                    <label for="partner-suffix">Suffix</label>
-                                                    <input class="form-control" id="partner-suffix"   value="">
-                                                </div>
-                                                <div class="form-group form-group-md col-xs-6">
-                                                    <label ><span class="weight600">&#42;</span>Country of citizenship</label>
-                                                    <select class="form-control ge-citizenship"  required="">
-                                                        <option value="">Select</option>
-                                                        <option value="United States of America">United States of America</option>
-                                                        <option value="Afghanistan">Afghanistan</option>
-                                                        <option value="Albania">Albania</option>
-                                                        <option value="Algeria">Algeria</option>
-                                                        <option value="American Samoa">American Samoa</option>
-                                                        <option value="Andorra">Andorra</option>
-                                                        <option value="Angola">Angola</option>
-                                                        <option value="Anguilla">Anguilla</option>
-                                                        <option value="Antarctica">Antarctica</option>
-                                                        <option value="Antigua and Barbuda">Antigua and Barbuda</option>
-                                                        <option value="Argentina">Argentina</option>
-                                                        <option value="Armenia">Armenia</option>
-                                                        <option value="Aruba">Aruba</option>
-                                                        <option value="Australia">Australia</option>
-                                                        <option value="Austria">Austria</option>
-                                                        <option value="Azerbaijan">Azerbaijan</option>
-                                                        <option value="Bahamas">Bahamas</option>
-                                                        <option value="Bahrain">Bahrain</option>
-                                                        <option value="Bangladesh">Bangladesh</option>
-                                                        <option value="Barbados">Barbados</option>
-                                                        <option value="Belarus">Belarus</option>
-                                                        <option value="Belgium">Belgium</option>
-                                                        <option value="Belize">Belize</option>
-                                                        <option value="Benin">Benin</option>
-                                                        <option value="Bermuda">Bermuda</option>
-                                                        <option value="Bhutan">Bhutan</option>
-                                                        <option value="Bolivia">Bolivia</option>
-                                                        <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
-                                                        <option value="Botswana">Botswana</option>
-                                                        <option value="Bouvet Island">Bouvet Island</option>
-                                                        <option value="Brazil">Brazil</option>
-                                                        <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
-                                                        <option value="Brunei Darussalam">Brunei Darussalam</option>
-                                                        <option value="Bulgaria">Bulgaria</option>
-                                                        <option value="Burkina Faso">Burkina Faso</option>
-                                                        <option value="Burundi">Burundi</option>
-                                                        <option value="Canada">Canada</option>
-                                                        <option value="Cambodia">Cambodia</option>
-                                                        <option value="Cameroon">Cameroon</option>
-                                                        <option value="Cape Verde">Cape Verde</option>
-                                                        <option value="Cayman Islands">Cayman Islands</option>
-                                                        <option value="Central African Republic">Central African Republic</option>
-                                                        <option value="Chad">Chad</option>
-                                                        <option value="Chile">Chile</option>
-                                                        <option value="China">China</option>
-                                                        <option value="Christmas Island">Christmas Island</option>
-                                                        <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
-                                                        <option value="Colombia">Colombia</option>
-                                                        <option value="Comoros">Comoros</option>
-                                                        <option value="Congo">Congo</option>
-                                                        <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
-                                                        <option value="Cook Islands">Cook Islands</option>
-                                                        <option value="Costa Rica">Costa Rica</option>
-                                                        <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
-                                                        <option value="Croatia">Croatia</option>
-                                                        <option value="Cuba">Cuba</option>
-                                                        <option value="Cyprus">Cyprus</option>
-                                                        <option value="Czech Republic">Czech Republic</option>
-                                                        <option value="Denmark">Denmark</option>
-                                                        <option value="Djibouti">Djibouti</option>
-                                                        <option value="Dominica">Dominica</option>
-                                                        <option value="Dominican Republic">Dominican Republic</option>
-                                                        <option value="East Timor">East Timor</option>
-                                                        <option value="Ecuador">Ecuador</option>
-                                                        <option value="Egypt">Egypt</option>
-                                                        <option value="El Salvador">El Salvador</option>
-                                                        <option value="Equatorial Guinea">Equatorial Guinea</option>
-                                                        <option value="Eritrea">Eritrea</option>
-                                                        <option value="Estonia">Estonia</option>
-                                                        <option value="Ethiopia">Ethiopia</option>
-                                                        <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
-                                                        <option value="Faroe Islands">Faroe Islands</option>
-                                                        <option value="Fiji">Fiji</option>
-                                                        <option value="Finland">Finland</option>
-                                                        <option value="France">France</option>
-                                                        <option value="French Guiana">French Guiana</option>
-                                                        <option value="French Polynesia">French Polynesia</option>
-                                                        <option value="French Southern Territories">French Southern Territories</option>
-                                                        <option value="Gabon">Gabon</option>
-                                                        <option value="Gambia">Gambia</option>
-                                                        <option value="Georgia">Georgia</option>
-                                                        <option value="Germany">Germany</option>
-                                                        <option value="Ghana">Ghana</option>
-                                                        <option value="Gibraltar">Gibraltar</option>
-                                                        <option value="Greece">Greece</option>
-                                                        <option value="Greenland">Greenland</option>
-                                                        <option value="Grenada">Grenada</option>
-                                                        <option value="Guadeloupe">Guadeloupe</option>
-                                                        <option value="Guam">Guam</option>
-                                                        <option value="Guatemala">Guatemala</option>
-                                                        <option value="Guinea">Guinea</option>
-                                                        <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
-                                                        <option value="Guyana">Guyana</option>
-                                                        <option value="Haiti">Haiti</option>
-                                                        <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
-                                                        <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
-                                                        <option value="Honduras">Honduras</option>
-                                                        <option value="Hong Kong">Hong Kong</option>
-                                                        <option value="Hungary">Hungary</option>
-                                                        <option value="Iceland">Iceland</option>
-                                                        <option value="India">India</option>
-                                                        <option value="Indonesia">Indonesia</option>
-                                                        <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
-                                                        <option value="Iraq">Iraq</option>
-                                                        <option value="Ireland">Ireland</option>
-                                                        <option value="Israel">Israel</option>
-                                                        <option value="Italy">Italy</option>
-                                                        <option value="Jamaica">Jamaica</option>
-                                                        <option value="Japan">Japan</option>
-                                                        <option value="Jordan">Jordan</option>
-                                                        <option value="Kazakstan">Kazakstan</option>
-                                                        <option value="Kenya">Kenya</option>
-                                                        <option value="Kiribati">Kiribati</option>
-                                                        <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
-                                                        <option value="Korea, Republic of">Korea, Republic of</option>
-                                                        <option value="Kuwait">Kuwait</option>
-                                                        <option value="Kyrgyzstan">Kyrgyzstan</option>
-                                                        <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
-                                                        <option value="Latvia">Latvia</option>
-                                                        <option value="Lebanon">Lebanon</option>
-                                                        <option value="Lesotho">Lesotho</option>
-                                                        <option value="Liberia">Liberia</option>
-                                                        <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
-                                                        <option value="Liechtenstein">Liechtenstein</option>
-                                                        <option value="Lithuania">Lithuania</option>
-                                                        <option value="Luxembourg">Luxembourg</option>
-                                                        <option value="Macau">Macau</option>
-                                                        <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
-                                                        <option value="Madagascar">Madagascar</option>
-                                                        <option value="Malawi">Malawi</option>
-                                                        <option value="Malaysia">Malaysia</option>
-                                                        <option value="Maldives">Maldives</option>
-                                                        <option value="Mali">Mali</option>
-                                                        <option value="Malta">Malta</option>
-                                                        <option value="Marshall Islands">Marshall Islands</option>
-                                                        <option value="Martinique">Martinique</option>
-                                                        <option value="Mauritania">Mauritania</option>
-                                                        <option value="Mauritius">Mauritius</option>
-                                                        <option value="Mayotte">Mayotte</option>
-                                                        <option value="Mexico">Mexico</option>
-                                                        <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
-                                                        <option value="Moldova, Republic of">Moldova, Republic of</option>
-                                                        <option value="Monaco">Monaco</option>
-                                                        <option value="Mongolia">Mongolia</option>
-                                                        <option value="Montserrat">Montserrat</option>
-                                                        <option value="Morocco">Morocco</option>
-                                                        <option value="Mozambique">Mozambique</option>
-                                                        <option value="Myanmar">Myanmar</option>
-                                                        <option value="Namibia">Namibia</option>
-                                                        <option value="Nauru">Nauru</option>
-                                                        <option value="Nepal">Nepal</option>
-                                                        <option value="Netherlands">Netherlands</option>
-                                                        <option value="Netherlands Antilles">Netherlands Antilles</option>
-                                                        <option value="New Caledonia">New Caledonia</option>
-                                                        <option value="New Zealand">New Zealand</option>
-                                                        <option value="Nicaragua">Nicaragua</option>
-                                                        <option value="Niger">Niger</option>
-                                                        <option value="Nigeria">Nigeria</option>
-                                                        <option value="Niue">Niue</option>
-                                                        <option value="Norfolk Island">Norfolk Island</option>
-                                                        <option value="Northern Mariana Islands">Northern Mariana Islands</option>
-                                                        <option value="Norway">Norway</option>
-                                                        <option value="Oman">Oman</option>
-                                                        <option value="Pakistan">Pakistan</option>
-                                                        <option value="Palau">Palau</option>
-                                                        <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
-                                                        <option value="Panama">Panama</option>
-                                                        <option value="Papua New Guinea">Papua New Guinea</option>
-                                                        <option value="Paraguay">Paraguay</option>
-                                                        <option value="Peru">Peru</option>
-                                                        <option value="Philippines">Philippines</option>
-                                                        <option value="Pitcairn">Pitcairn</option>
-                                                        <option value="Poland">Poland</option>
-                                                        <option value="Portugal">Portugal</option>
-                                                        <option value="Puerto Rico">Puerto Rico</option>
-                                                        <option value="Qatar">Qatar</option>
-                                                        <option value="Reunion">Reunion</option>
-                                                        <option value="Romania">Romania</option>
-                                                        <option value="Russian Federation">Russian Federation</option>
-                                                        <option value="Rwanda">Rwanda</option>
-                                                        <option value="Saint Helena">Saint Helena</option>
-                                                        <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
-                                                        <option value="Saint Lucia">Saint Lucia</option>
-                                                        <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
-                                                        <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
-                                                        <option value="Samoa">Samoa</option>
-                                                        <option value="San Marino">San Marino</option>
-                                                        <option value="Sao Tome and Principe">Sao Tome and Principe</option>
-                                                        <option value="Saudi Arabia">Saudi Arabia</option>
-                                                        <option value="Senegal">Senegal</option>
-                                                        <option value="Seychelles">Seychelles</option>
-                                                        <option value="Sierra Leone">Sierra Leone</option>
-                                                        <option value="Singapore">Singapore</option>
-                                                        <option value="Slovakia">Slovakia</option>
-                                                        <option value="Slovenia">Slovenia</option>
-                                                        <option value="Solomon Islands">Solomon Islands</option>
-                                                        <option value="Somalia">Somalia</option>
-                                                        <option value="South Africa">South Africa</option>
-                                                        <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
-                                                        <option value="Spain">Spain</option>
-                                                        <option value="Sri Lanka">Sri Lanka</option>
-                                                        <option value="Sudan">Sudan</option>
-                                                        <option value="Suriname">Suriname</option>
-                                                        <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
-                                                        <option value="Swaziland">Swaziland</option>
-                                                        <option value="Sweden">Sweden</option>
-                                                        <option value="Switzerland">Switzerland</option>
-                                                        <option value="Syrian Arab Republic">Syrian Arab Republic</option>
-                                                        <option value="Taiwan">Taiwan</option>
-                                                        <option value="Tajikistan">Tajikistan</option>
-                                                        <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
-                                                        <option value="Thailand">Thailand</option>
-                                                        <option value="Togo">Togo</option>
-                                                        <option value="Tokelau">Tokelau</option>
-                                                        <option value="Tonga">Tonga</option>
-                                                        <option value="Trinidad and Tobago">Trinidad and Tobago</option>
-                                                        <option value="Tunisia">Tunisia</option>
-                                                        <option value="Turkey">Turkey</option>
-                                                        <option value="Turkmenistan">Turkmenistan</option>
-                                                        <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
-                                                        <option value="Tuvalu">Tuvalu</option>
-                                                        <option value="Uganda">Uganda</option>
-                                                        <option value="Ukraine">Ukraine</option>
-                                                        <option value="United Arab Emirates">United Arab Emirates</option>
-                                                        <option value="United Kingdom">United Kingdom</option>
-                                                        <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
-                                                        <option value="Uruguay">Uruguay</option>
-                                                        <option value="Uzbekistan">Uzbekistan</option>
-                                                        <option value="Vanuatu">Vanuatu</option>
-                                                        <option value="Venezuela">Venezuela</option>
-                                                        <option value="Viet Nam">Viet Nam</option>
-                                                        <option value="Virgin Islands, British">Virgin Islands, British</option>
-                                                        <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
-                                                        <option value="Wallis and Futuna">Wallis and Futuna</option>
-                                                        <option value="Western Sahara">Western Sahara</option>
-                                                        <option value="Yemen">Yemen</option>
-                                                        <option value="Yugoslavia">Yugoslavia</option>
-                                                        <option value="Zambia">Zambia</option>
-                                                        <option value="Zimbabwe">Zimbabwe</option>
-                                                        <option value="Unknown">Unknown</option>
-                                                    </select>
-                                                </div>
-                                            </div>
-                                        </fieldset>
-                                        <fieldset aria-labelledby="proprietorinfo" id="none-individual-partner-entity-new" style="display: none;">
-                                            <div class="row">
-                                                <div class="form-group form-group-md col-xs-6">
-                                                    <label for="ownername"><span class="weight600">&#42;</span>General partner name</label>
-                                                    <input type="text" class="form-control rounded-borders ge-name"  required  value="">
-                                                </div>
-                                                <div class="form-group form-group-md col-xs-6">
-                                                    <label><span class="weight600">&#42;</span>State where legally organized</label>
-                                                    <select  class="form-control ge-state">
-                                                        <option value="">Select</option>
-                                                        <option value="Alabama">Alabama</option>
-                                                        <option value="Alaska">Alaska</option>
-                                                        <option value="Arizona">Arizona</option>
-                                                        <option value="Arkansas">Arkansas</option>
-                                                        <option value="California">California</option>
-                                                        <option value="Colorado">Colorado</option>
-                                                        <option value="Connecticut">Connecticut</option>
-                                                        <option value="Delaware">Delaware</option>
-                                                        <option value="District of Columbia">District of Columbia</option>
-                                                        <option value="Florida">Florida</option>
-                                                        <option value="Georgia">Georgia</option>
-                                                        <option value="Hawaii">Hawaii</option>
-                                                        <option value="Idaho">Idaho</option>
-                                                        <option value="Illinois">Illinois</option>
-                                                        <option value="Indiana">Indiana</option>
-                                                        <option value="Iowa">Iowa</option>
-                                                        <option value="Kansas">Kansas</option>
-                                                        <option value="Kentucky">Kentucky</option>
-                                                        <option value="Louisiana">Louisiana</option>
-                                                        <option value="Maine">Maine</option>
-                                                        <option value="Maryland">Maryland</option>
-                                                        <option value="Massachusetts">Massachusetts</option>
-                                                        <option value="Michigan">Michigan</option>
-                                                        <option value="Minnesota">Minnesota</option>
-                                                        <option value="Mississippi">Mississippi</option>
-                                                        <option value="Missouri">Missouri</option>
-                                                        <option value="Montana">Montana</option>
-                                                        <option value="Nebraska">Nebraska</option>
-                                                        <option value="Nevada">Nevada</option>
-                                                        <option value="New Hampshire">New Hampshire</option>
-                                                        <option value="New Jersey">New Jersey</option>
-                                                        <option value="New Mexico">New Mexico</option>
-                                                        <option value="New York">New York</option>
-                                                        <option value="North Carolina">North Carolina</option>
-                                                        <option value="North Dakota">North Dakota</option>
-                                                        <option value="Ohio">Ohio</option>
-                                                        <option value="Oklahoma">Oklahoma</option>
-                                                        <option value="Oregon">Oregon</option>
-                                                        <option value="Pennsylvania">Pennsylvania</option>
-                                                        <option value="Rhode Island">Rhode Island</option>
-                                                        <option value="South Carolina">South Carolina</option>
-                                                        <option value="South Dakota">South Dakota</option>
-                                                        <option value="Tennessee">Tennessee</option>
-                                                        <option value="Texas">Texas</option>
-                                                        <option value="Utah">Utah</option>
-                                                        <option value="Vermont">Vermont</option>
-                                                        <option value="Virginia">Virginia</option>
-                                                        <option value="Washington">Washington</option>
-                                                        <option value="West Virginia">West Virginia</option>
-                                                        <option value="Wisconsin">Wisconsin</option>
-                                                        <option value="Wyoming">Wyoming</option>
-                                                    </select>
-                                                </div>
-                                            </div>
-                                        </fieldset>
-                                    </div> <!-- end of arrary dto object -->
-                                </div>
-                            </div>
-                            <!--END hidden content-->
-                            <div class="appendpartner col-xs-12"></div>
-                            <div class="row" id="hideshow_addpartner">
-
-                                <div class="col-xs-12 form-group form-group-md" aria-label="add a partner">
-                                    <div class="inlinebuttons btn-group btn-group-justified">
-                                        <div class="btn-group col-xs-6">
-                                            <button type="button" class="btn btn-sm btn-success addinitial" id="addpartner">Add Partner</button>
-                                        </div>
-                                    </div>
-                                </div><!--// add button-->
-                            </div><!--// hide / show add partner-->
-                            <!--END Sole Proprietor Information Form-->
-                            <!--START Owner Address Information Form-->
-                            <div class="card-text">
-                                <h2 class="card-title weight600" id="addressinfo">Owner Address Information</h2>
-                            </div>
-                            <fieldset aria-labelledby="addressinfo">
-                                <div class="row">
-                                    <div class="form-group form-group-md col-md-12 col-lg-7">
-                                        <label for="OwnerAddressCountry"><span class="weight600">&#42;</span>Country / U.S. territory</label>
-                                        <select class="form-control" id="OwnerAddressCountry" name="territory" th:field="${owner.country}" >
-                                            <option value="">Select</option>
-                                            <option value="United States of America">United States of America</option>
-                                            <option value="Afghanistan">Afghanistan</option>
-                                            <option value="Albania">Albania</option>
-                                            <option value="Algeria">Algeria</option>
-                                            <option value="American Samoa">American Samoa</option>
-                                            <option value="Andorra">Andorra</option>
-                                            <option value="Angola">Angola</option>
-                                            <option value="Anguilla">Anguilla</option>
-                                            <option value="Antarctica">Antarctica</option>
-                                            <option value="Antigua and Barbuda">Antigua and Barbuda</option>
-                                            <option value="Argentina">Argentina</option>
-                                            <option value="Armenia">Armenia</option>
-                                            <option value="Aruba">Aruba</option>
-                                            <option value="Australia">Australia</option>
-                                            <option value="Austria">Austria</option>
-                                            <option value="Azerbaijan">Azerbaijan</option>
-                                            <option value="Bahamas">Bahamas</option>
-                                            <option value="Bahrain">Bahrain</option>
-                                            <option value="Bangladesh">Bangladesh</option>
-                                            <option value="Barbados">Barbados</option>
-                                            <option value="Belarus">Belarus</option>
-                                            <option value="Belgium">Belgium</option>
-                                            <option value="Belize">Belize</option>
-                                            <option value="Benin">Benin</option>
-                                            <option value="Bermuda">Bermuda</option>
-                                            <option value="Bhutan">Bhutan</option>
-                                            <option value="Bolivia">Bolivia</option>
-                                            <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
-                                            <option value="Botswana">Botswana</option>
-                                            <option value="Bouvet Island">Bouvet Island</option>
-                                            <option value="Brazil">Brazil</option>
-                                            <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
-                                            <option value="Brunei Darussalam">Brunei Darussalam</option>
-                                            <option value="Bulgaria">Bulgaria</option>
-                                            <option value="Burkina Faso">Burkina Faso</option>
-                                            <option value="Burundi">Burundi</option>
-                                            <option value="Canada">Canada</option>
-                                            <option value="Cambodia">Cambodia</option>
-                                            <option value="Cameroon">Cameroon</option>
-                                            <option value="Cape Verde">Cape Verde</option>
-                                            <option value="Cayman Islands">Cayman Islands</option>
-                                            <option value="Central African Republic">Central African Republic</option>
-                                            <option value="Chad">Chad</option>
-                                            <option value="Chile">Chile</option>
-                                            <option value="China">China</option>
-                                            <option value="Christmas Island">Christmas Island</option>
-                                            <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
-                                            <option value="Colombia">Colombia</option>
-                                            <option value="Comoros">Comoros</option>
-                                            <option value="Congo">Congo</option>
-                                            <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
-                                            <option value="Cook Islands">Cook Islands</option>
-                                            <option value="Costa Rica">Costa Rica</option>
-                                            <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
-                                            <option value="Croatia">Croatia</option>
-                                            <option value="Cuba">Cuba</option>
-                                            <option value="Cyprus">Cyprus</option>
-                                            <option value="Czech Republic">Czech Republic</option>
-                                            <option value="Denmark">Denmark</option>
-                                            <option value="Djibouti">Djibouti</option>
-                                            <option value="Dominica">Dominica</option>
-                                            <option value="Dominican Republic">Dominican Republic</option>
-                                            <option value="East Timor">East Timor</option>
-                                            <option value="Ecuador">Ecuador</option>
-                                            <option value="Egypt">Egypt</option>
-                                            <option value="El Salvador">El Salvador</option>
-                                            <option value="Equatorial Guinea">Equatorial Guinea</option>
-                                            <option value="Eritrea">Eritrea</option>
-                                            <option value="Estonia">Estonia</option>
-                                            <option value="Ethiopia">Ethiopia</option>
-                                            <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
-                                            <option value="Faroe Islands">Faroe Islands</option>
-                                            <option value="Fiji">Fiji</option>
-                                            <option value="Finland">Finland</option>
-                                            <option value="France">France</option>
-                                            <option value="French Guiana">French Guiana</option>
-                                            <option value="French Polynesia">French Polynesia</option>
-                                            <option value="French Southern Territories">French Southern Territories</option>
-                                            <option value="Gabon">Gabon</option>
-                                            <option value="Gambia">Gambia</option>
-                                            <option value="Georgia">Georgia</option>
-                                            <option value="Germany">Germany</option>
-                                            <option value="Ghana">Ghana</option>
-                                            <option value="Gibraltar">Gibraltar</option>
-                                            <option value="Greece">Greece</option>
-                                            <option value="Greenland">Greenland</option>
-                                            <option value="Grenada">Grenada</option>
-                                            <option value="Guadeloupe">Guadeloupe</option>
-                                            <option value="Guam">Guam</option>
-                                            <option value="Guatemala">Guatemala</option>
-                                            <option value="Guinea">Guinea</option>
-                                            <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
-                                            <option value="Guyana">Guyana</option>
-                                            <option value="Haiti">Haiti</option>
-                                            <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
-                                            <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
-                                            <option value="Honduras">Honduras</option>
-                                            <option value="Hong Kong">Hong Kong</option>
-                                            <option value="Hungary">Hungary</option>
-                                            <option value="Iceland">Iceland</option>
-                                            <option value="India">India</option>
-                                            <option value="Indonesia">Indonesia</option>
-                                            <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
-                                            <option value="Iraq">Iraq</option>
-                                            <option value="Ireland">Ireland</option>
-                                            <option value="Israel">Israel</option>
-                                            <option value="Italy">Italy</option>
-                                            <option value="Jamaica">Jamaica</option>
-                                            <option value="Japan">Japan</option>
-                                            <option value="Jordan">Jordan</option>
-                                            <option value="Kazakstan">Kazakstan</option>
-                                            <option value="Kenya">Kenya</option>
-                                            <option value="Kiribati">Kiribati</option>
-                                            <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
-                                            <option value="Korea, Republic of">Korea, Republic of</option>
-                                            <option value="Kuwait">Kuwait</option>
-                                            <option value="Kyrgyzstan">Kyrgyzstan</option>
-                                            <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
-                                            <option value="Latvia">Latvia</option>
-                                            <option value="Lebanon">Lebanon</option>
-                                            <option value="Lesotho">Lesotho</option>
-                                            <option value="Liberia">Liberia</option>
-                                            <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
-                                            <option value="Liechtenstein">Liechtenstein</option>
-                                            <option value="Lithuania">Lithuania</option>
-                                            <option value="Luxembourg">Luxembourg</option>
-                                            <option value="Macau">Macau</option>
-                                            <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
-                                            <option value="Madagascar">Madagascar</option>
-                                            <option value="Malawi">Malawi</option>
-                                            <option value="Malaysia">Malaysia</option>
-                                            <option value="Maldives">Maldives</option>
-                                            <option value="Mali">Mali</option>
-                                            <option value="Malta">Malta</option>
-                                            <option value="Marshall Islands">Marshall Islands</option>
-                                            <option value="Martinique">Martinique</option>
-                                            <option value="Mauritania">Mauritania</option>
-                                            <option value="Mauritius">Mauritius</option>
-                                            <option value="Mayotte">Mayotte</option>
-                                            <option value="Mexico">Mexico</option>
-                                            <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
-                                            <option value="Moldova, Republic of">Moldova, Republic of</option>
-                                            <option value="Monaco">Monaco</option>
-                                            <option value="Mongolia">Mongolia</option>
-                                            <option value="Montserrat">Montserrat</option>
-                                            <option value="Morocco">Morocco</option>
-                                            <option value="Mozambique">Mozambique</option>
-                                            <option value="Myanmar">Myanmar</option>
-                                            <option value="Namibia">Namibia</option>
-                                            <option value="Nauru">Nauru</option>
-                                            <option value="Nepal">Nepal</option>
-                                            <option value="Netherlands">Netherlands</option>
-                                            <option value="Netherlands Antilles">Netherlands Antilles</option>
-                                            <option value="New Caledonia">New Caledonia</option>
-                                            <option value="New Zealand">New Zealand</option>
-                                            <option value="Nicaragua">Nicaragua</option>
-                                            <option value="Niger">Niger</option>
-                                            <option value="Nigeria">Nigeria</option>
-                                            <option value="Niue">Niue</option>
-                                            <option value="Norfolk Island">Norfolk Island</option>
-                                            <option value="Northern Mariana Islands">Northern Mariana Islands</option>
-                                            <option value="Norway">Norway</option>
-                                            <option value="Oman">Oman</option>
-                                            <option value="Pakistan">Pakistan</option>
-                                            <option value="Palau">Palau</option>
-                                            <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
-                                            <option value="Panama">Panama</option>
-                                            <option value="Papua New Guinea">Papua New Guinea</option>
-                                            <option value="Paraguay">Paraguay</option>
-                                            <option value="Peru">Peru</option>
-                                            <option value="Philippines">Philippines</option>
-                                            <option value="Pitcairn">Pitcairn</option>
-                                            <option value="Poland">Poland</option>
-                                            <option value="Portugal">Portugal</option>
-                                            <option value="Puerto Rico">Puerto Rico</option>
-                                            <option value="Qatar">Qatar</option>
-                                            <option value="Reunion">Reunion</option>
-                                            <option value="Romania">Romania</option>
-                                            <option value="Russian Federation">Russian Federation</option>
-                                            <option value="Rwanda">Rwanda</option>
-                                            <option value="Saint Helena">Saint Helena</option>
-                                            <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
-                                            <option value="Saint Lucia">Saint Lucia</option>
-                                            <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
-                                            <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
-                                            <option value="Samoa">Samoa</option>
-                                            <option value="San Marino">San Marino</option>
-                                            <option value="Sao Tome and Principe">Sao Tome and Principe</option>
-                                            <option value="Saudi Arabia">Saudi Arabia</option>
-                                            <option value="Senegal">Senegal</option>
-                                            <option value="Seychelles">Seychelles</option>
-                                            <option value="Sierra Leone">Sierra Leone</option>
-                                            <option value="Singapore">Singapore</option>
-                                            <option value="Slovakia">Slovakia</option>
-                                            <option value="Slovenia">Slovenia</option>
-                                            <option value="Solomon Islands">Solomon Islands</option>
-                                            <option value="Somalia">Somalia</option>
-                                            <option value="South Africa">South Africa</option>
-                                            <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
-                                            <option value="Spain">Spain</option>
-                                            <option value="Sri Lanka">Sri Lanka</option>
-                                            <option value="Sudan">Sudan</option>
-                                            <option value="Suriname">Suriname</option>
-                                            <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
-                                            <option value="Swaziland">Swaziland</option>
-                                            <option value="Sweden">Sweden</option>
-                                            <option value="Switzerland">Switzerland</option>
-                                            <option value="Syrian Arab Republic">Syrian Arab Republic</option>
-                                            <option value="Taiwan">Taiwan</option>
-                                            <option value="Tajikistan">Tajikistan</option>
-                                            <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
-                                            <option value="Thailand">Thailand</option>
-                                            <option value="Togo">Togo</option>
-                                            <option value="Tokelau">Tokelau</option>
-                                            <option value="Tonga">Tonga</option>
-                                            <option value="Trinidad and Tobago">Trinidad and Tobago</option>
-                                            <option value="Tunisia">Tunisia</option>
-                                            <option value="Turkey">Turkey</option>
-                                            <option value="Turkmenistan">Turkmenistan</option>
-                                            <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
-                                            <option value="Tuvalu">Tuvalu</option>
-                                            <option value="Uganda">Uganda</option>
-                                            <option value="Ukraine">Ukraine</option>
-                                            <option value="United Arab Emirates">United Arab Emirates</option>
-                                            <option value="United Kingdom">United Kingdom</option>
-                                            <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
-                                            <option value="Uruguay">Uruguay</option>
-                                            <option value="Uzbekistan">Uzbekistan</option>
-                                            <option value="Vanuatu">Vanuatu</option>
-                                            <option value="Venezuela">Venezuela</option>
-                                            <option value="Viet Nam">Viet Nam</option>
-                                            <option value="Virgin Islands, British">Virgin Islands, British</option>
-                                            <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
-                                            <option value="Wallis and Futuna">Wallis and Futuna</option>
-                                            <option value="Western Sahara">Western Sahara</option>
-                                            <option value="Yemen">Yemen</option>
-                                            <option value="Yugoslavia">Yugoslavia</option>
-                                            <option value="Zambia">Zambia</option>
-                                            <option value="Zimbabwe">Zimbabwe</option>
-                                            <option value="Unknown">Unknown</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group form-group-md col-md-12 col-lg-9">
-                                        <label for="ownerAddress1"><span class="weight600">&#42;</span>Address line 1</label>
-                                        <input type="text" class="form-control" id="ownerAddress1" th:value="${owner.address1}" >
-                                    </div>
-                                    <div class="form-group form-group-md col-md-12 col-lg-9">
-                                        <label for="addressline2">Address line 2</label>
-                                        <input type="text" class="form-control" id="addressline2" >
-                                    </div>
-                                    <div class="form-group form-group-md col-md-12 col-lg-9">
-                                        <label for="addressline3">Address line 3</label>
-                                        <input type="text" class="form-control" id="addressline3" >
-                                    </div>
-                                    <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                        <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
-                                        <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}">
-                                    </div>
-                                    <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                        <label for="ownerState"><span class="weight600">&#42;</span>State/Province/Territory</label>
-                                        <select class="form-control" id="ownerState" th:field="${owner.state}" required>
-                                            <option value="">Select</option>
-                                            <option value="Alabama">Alabama</option>
-                                            <option value="Alaska">Alaska</option>
-                                            <option value="Arizona">Arizona</option>
-                                            <option value="Arkansas">Arkansas</option>
-                                            <option value="California">California</option>
-                                            <option value="Colorado">Colorado</option>
-                                            <option value="Connecticut">Connecticut</option>
-                                            <option value="Delaware">Delaware</option>
-                                            <option value="District of Columbia">District of Columbia</option>
-                                            <option value="Florida">Florida</option>
-                                            <option value="Georgia">Georgia</option>
-                                            <option value="Hawaii">Hawaii</option>
-                                            <option value="Idaho">Idaho</option>
-                                            <option value="Illinois">Illinois</option>
-                                            <option value="Indiana">Indiana</option>
-                                            <option value="Iowa">Iowa</option>
-                                            <option value="Kansas">Kansas</option>
-                                            <option value="Kentucky">Kentucky</option>
-                                            <option value="Louisiana">Louisiana</option>
-                                            <option value="Maine">Maine</option>
-                                            <option value="Maryland">Maryland</option>
-                                            <option value="Massachusetts">Massachusetts</option>
-                                            <option value="Michigan">Michigan</option>
-                                            <option value="Minnesota">Minnesota</option>
-                                            <option value="Mississippi">Mississippi</option>
-                                            <option value="Missouri">Missouri</option>
-                                            <option value="Montana">Montana</option>
-                                            <option value="Nebraska">Nebraska</option>
-                                            <option value="Nevada">Nevada</option>
-                                            <option value="New Hampshire">New Hampshire</option>
-                                            <option value="New Jersey">New Jersey</option>
-                                            <option value="New Mexico">New Mexico</option>
-                                            <option value="New York">New York</option>
-                                            <option value="North Carolina">North Carolina</option>
-                                            <option value="North Dakota">North Dakota</option>
-                                            <option value="Ohio">Ohio</option>
-                                            <option value="Oklahoma">Oklahoma</option>
-                                            <option value="Oregon">Oregon</option>
-                                            <option value="Pennsylvania">Pennsylvania</option>
-                                            <option value="Rhode Island">Rhode Island</option>
-                                            <option value="South Carolina">South Carolina</option>
-                                            <option value="South Dakota">South Dakota</option>
-                                            <option value="Tennessee">Tennessee</option>
-                                            <option value="Texas">Texas</option>
-                                            <option value="Utah">Utah</option>
-                                            <option value="Vermont">Vermont</option>
-                                            <option value="Virginia">Virginia</option>
-                                            <option value="Washington">Washington</option>
-                                            <option value="West Virginia">West Virginia</option>
-                                            <option value="Wisconsin">Wisconsin</option>
-                                            <option value="Wyoming">Wyoming</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group form-group-md col-xs-12 col-sm-5">
-                                        <label for="ownerZipcode"><span class="weight600">&#42;</span>Zip code/Postal code</label>
-                                        <input type="text" class="form-control" id="ownerZipcode" placeholder=""  th:value="${owner.zipcode}">
-                                    </div>
-                                </div>
-                            </fieldset>
-                            <!--END Owner Address Information Form-->
-                            <!--START Additional Information Form-->
-                            <div class="card-text">
-                                <h2 class="card-title weight600" id="additionalinfo">Additional Information</h2>
-                            </div>
-                            <fieldset aria-labelledby="additionalinfo">
-                                <div class="row">
-                                    <div class="form-group form-group-md col-xs-12 col-md-6">
-                                        <label for="ownerEmail"><span class="weight600">&#42;</span>Email address <a href="#" data-toggle="tooltip" title="The USPTO will use this email address to send correspondence regarding this application or registration. It is critical to ensure this email address is current." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
-                                        <input type="text" class="form-control" id="ownerEmail"   th:value="${owner.email}" >
-                                    </div>
-                                    <div class="form-group form-group-md col-xs-12 col-md-6">
-                                        <label for="webaddress">Website address</label>
-                                        <input type="text" class="form-control" id="webaddress"  th:value="${owner.webSiteURL}">
-                                    </div>
-                                    <div class="row">
-                                        <div class="col-xs-12">
-                                            <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-4">
-                                                <label for="phonenumbertype">Phone type</label>
-                                                <select class="form-control" id="phonenumbertype" name="phonenumbertype">
-                                                    <option value="Type">Type</option>
-                                                    <option value="Cell">Cell</option>
-                                                    <option value="Home">Home</option>
-                                                    <option value="Work">Work</option>
-                                                    <option value="Fax">Fax</option>
-                                                </select>
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-md-6 col-lg-6">
-                                                <label for="phone">Phone number</label>
-                                                <input type="text" class="form-control" id="phone" th:value="${owner.primaryPhonenumber}">
-                                            </div>
-                                            <div class="form-group form-group-md col-xs-12 col-md-2 col-lg-2">
-                                                <label for="extension">Ext.</label>
-                                                <input type="text" class="form-control" id="extension">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-5">
+                                                <label for="ownerZipcode"><span class="weight600">&#42;</span>Zip code/Postal code</label>
+                                                <input type="text" class="form-control" id="ownerZipcode" placeholder=""  th:value="${owner.zipcode}">
                                             </div>
                                         </div>
+                                    </fieldset>
+                                    <!--END Owner Address Information Form-->
+                                    <!--START Additional Information Form-->
+                                    <div class="card-text">
+                                        <h2 class="card-title weight600" id="additionalinfo">Additional Information</h2>
                                     </div>
-                                    <div class="row" style="display:none; max-height: 1px;">
+                                    <fieldset aria-labelledby="additionalinfo">
+                                        <div class="row">
+                                            <div class="form-group form-group-md col-xs-12 col-md-6">
+                                                <label for="ownerEmail"><span class="weight600">&#42;</span>Email address <a href="#" data-toggle="tooltip" title="The USPTO will use this email address to send correspondence regarding this application or registration. It is critical to ensure this email address is current." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
+                                                <input type="text" class="form-control" id="ownerEmail"   th:value="${owner.email}" >
+                                            </div>
+                                            <div class="form-group form-group-md col-xs-12 col-md-6">
+                                                <label for="webaddress">Website address</label>
+                                                <input type="text" class="form-control" id="webaddress"  th:value="${owner.webSiteURL}">
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-xs-12">
+                                                    <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-4">
+                                                        <label for="phonenumbertype">Phone type</label>
+                                                        <select class="form-control" id="phonenumbertype" name="phonenumbertype">
+                                                            <option value="Type">Type</option>
+                                                            <option value="Cell">Cell</option>
+                                                            <option value="Home">Home</option>
+                                                            <option value="Work">Work</option>
+                                                            <option value="Fax">Fax</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-md-6 col-lg-6">
+                                                        <label for="phone">Phone number</label>
+                                                        <input type="text" class="form-control" id="phone" th:value="${owner.primaryPhonenumber}">
+                                                    </div>
+                                                    <div class="form-group form-group-md col-xs-12 col-md-2 col-lg-2">
+                                                        <label for="extension">Ext.</label>
+                                                        <input type="text" class="form-control" id="extension">
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="row" style="display:none; max-height: 1px;">
+                                            </div>
+                                        </div>
+                                    </fieldset>
+                                </div>
+                                <div class="inlinebuttons btn-group btn-group-justified  owner-form-buttons" role="navigation" aria-label="view previous or next page" id="prevnxt">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm btn-primary fill next" id="doneButton" value="next" >Done
+                                            <div class="round"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+                                            </div>
+                                        </button>
                                     </div>
                                 </div>
-                            </fieldset>
+                                <!--END Additional Information Form-->
+                            </div><!--END Content Div-->
                         </div>
-                        <div class="inlinebuttons btn-group btn-group-justified  owner-form-buttons" role="navigation" aria-label="view previous or next page" id="prevnxt">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm btn-primary fill next" id="doneButton" value="next" >Done
-                                    <div class="round"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
-                                    </div>
-                                </button>
-                            </div>
-                        </div>
-                        <!--END Additional Information Form-->
-                    </div><!--END Content Div-->
+                    </div><!--END container div-->
                 </div>
-            </div><!--END container div-->
+            </main>
         </div>
-    </main>
-</div>
-</div>
+    </div>
 
 <!--load model attribute for Jquery consumption  -->
 <script th:inline="javascript">

--- a/PTO-WEB/src/main/resources/templates/application/owner/solP/ownerInfo2.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/solP/ownerInfo2.html
@@ -87,7 +87,7 @@
                                 </select>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                 <select class="form-control" id="additional-name-type" th:field="*{ownerType}">
                                     <option value="">Select</option>
                                     <option value="DBA">Doing Business As (DBA)</option>

--- a/PTO-WEB/src/main/resources/templates/application/owner/solP/ownerInfoEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/solP/ownerInfoEdit.html
@@ -6,851 +6,853 @@
     <title>Owner Information</title>
 </head>
 <body>
-<div class="row content"  style="display: none;">
-    <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
-        <div class="row" >
-            <div class="col-xs-12">
-                <!--START Content Div-->
-                <div class="row">
-                    <section class="col-xs-12 steps breadcrumb-steps" aria-label="progress tracker">
-                        <div class="row displaycell">
-                            <div class="col-xs-2 one" id="bs-header1">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>1</span>
+    <div class="container-fluid">
+        <div class="row content"  style="display: none;">
+            <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
+                <div class="row" >
+                    <div class="col-xs-12">
+                        <!--START Content Div-->
+                        <div class="row">
+                            <section class="col-xs-12 steps breadcrumb-steps" aria-label="progress tracker">
+                                <div class="row displaycell">
+                                    <div class="col-xs-2 one" id="bs-header1">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>1</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link1">
+                                                <p class="first">Your details</p>
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link1">
-                                        <p class="first">Your details</p>
+                                    <div class="col-xs-2 two" id="bs-header2">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>2</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link2">
+                                                <p>Trademark details</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 three" id="bs-header3">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>3</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link3">
+                                                <p>Goods and services</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 four" id="bs-header4">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>4</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link4">
+                                                <p>Basis</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 five" id="bs-header5">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>5</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link5">
+                                                <p>Additional info</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-2 six" id="bs-header6">
+                                        <div class="row">
+                                            <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
+                                                <span>6</span>
+                                            </div>
+                                            <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link6">
+                                                <p>Confirm and pay</p>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-xs-2 two" id="bs-header2">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>2</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link2">
-                                        <p>Trademark details</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 three" id="bs-header3">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>3</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link3">
-                                        <p>Goods and services</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 four" id="bs-header4">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>4</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link4">
-                                        <p>Basis</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 five" id="bs-header5">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>5</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link5">
-                                        <p>Additional info</p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-2 six" id="bs-header6">
-                                <div class="row">
-                                    <div class="col-xs-3 col-sm-5 col-md-4 col-lg-4 number">
-                                        <span>6</span>
-                                    </div>
-                                    <div class="col-xs-9 col-sm-7 col-md-8 col-lg-8" id="bs-link6">
-                                        <p>Confirm and pay</p>
-                                    </div>
-                                </div>
-                            </div>
+                            </section>
                         </div>
-                    </section>
-                </div>
-                <div class="row" style="">
-                    <div class="row">
-                        <div class="col-xs-6">
-                            <h1 style="margin-left: 15px;">Edit Owner Information</h1>
-                        </div>
-                    </div>
-                    <div class="col-xs-12 text-left">
-                        <!--START Owner Information Form-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="ownerinfo">Owner Information</h2>
-                        </div>
-                        <fieldset aria-labelledby="ownerinfo">
+                        <div class="row" style="">
                             <div class="row">
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
-                                    <input type="text" class="form-control"  id="ownername"  th:value="${owner.getOwnerName()}">
-                                </div>
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="stateoforg"><span class="weight600">&#42;</span>State of organization</label>
-                                    <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}" >
-                                        <option value="">Select</option>
-                                        <option value="Alabama">Alabama</option>
-                                        <option value="Alaska">Alaska</option>
-                                        <option value="Arizona">Arizona</option>
-                                        <option value="Arkansas">Arkansas</option>
-                                        <option value="California">California</option>
-                                        <option value="Colorado">Colorado</option>
-                                        <option value="Connecticut">Connecticut</option>
-                                        <option value="Delaware">Delaware</option>
-                                        <option value="District of Columbia">District of Columbia</option>
-                                        <option value="Florida">Florida</option>
-                                        <option value="Georgia">Georgia</option>
-                                        <option value="Hawaii">Hawaii</option>
-                                        <option value="Idaho">Idaho</option>
-                                        <option value="Illinois">Illinois</option>
-                                        <option value="Indiana">Indiana</option>
-                                        <option value="Iowa">Iowa</option>
-                                        <option value="Kansas">Kansas</option>
-                                        <option value="Kentucky">Kentucky</option>
-                                        <option value="Louisiana">Louisiana</option>
-                                        <option value="Maine">Maine</option>
-                                        <option value="Maryland">Maryland</option>
-                                        <option value="Massachusetts">Massachusetts</option>
-                                        <option value="Michigan">Michigan</option>
-                                        <option value="Minnesota">Minnesota</option>
-                                        <option value="Mississippi">Mississippi</option>
-                                        <option value="Missouri">Missouri</option>
-                                        <option value="Montana">Montana</option>
-                                        <option value="Nebraska">Nebraska</option>
-                                        <option value="Nevada">Nevada</option>
-                                        <option value="New Hampshire">New Hampshire</option>
-                                        <option value="New Jersey">New Jersey</option>
-                                        <option value="New Mexico">New Mexico</option>
-                                        <option value="New York">New York</option>
-                                        <option value="North Carolina">North Carolina</option>
-                                        <option value="North Dakota">North Dakota</option>
-                                        <option value="Ohio">Ohio</option>
-                                        <option value="Oklahoma">Oklahoma</option>
-                                        <option value="Oregon">Oregon</option>
-                                        <option value="Pennsylvania">Pennsylvania</option>
-                                        <option value="Rhode Island">Rhode Island</option>
-                                        <option value="South Carolina">South Carolina</option>
-                                        <option value="South Dakota">South Dakota</option>
-                                        <option value="Tennessee">Tennessee</option>
-                                        <option value="Texas">Texas</option>
-                                        <option value="Utah">Utah</option>
-                                        <option value="Vermont">Vermont</option>
-                                        <option value="Virginia">Virginia</option>
-                                        <option value="Washington">Washington</option>
-                                        <option value="West Virginia">West Virginia</option>
-                                        <option value="Wisconsin">Wisconsin</option>
-                                        <option value="Wyoming">Wyoming</option>
-                                    </select>
-                                </div>
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
-                                    <select class="form-control" id="additional-name-type"  th:field="${owner.ownerType}">
-                                        <option value="">Select</option>
-                                        <option value="DBA">Doing Business As (DBA)</option>
-                                        <option value="TA">Trading As (TA)</option>
-                                        <option value="AKA">Also Known As (AKA)</option>
-                                        <option value="Formerly">Formerly</option>
-                                    </select>
-                                </div>
-
-                                <th:block  th:if="${owner.isAlternameSet() == true}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype">
-                                        <label for="nameoftype">Name</label>
-                                        <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
-                                    </div>
-
-                                </th:block>
-
-                                <th:block  th:if="${owner.isAlternameSet() == false}">
-                                    <div class="form-group form-group-md col-xs-6" id="nametype" style="display: none;">
-                                        <label for="nameoftype">Name</label>
-                                        <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
-                                    </div>
-
-                                </th:block>
-
-
-
-                            </div>
-                        </fieldset>
-                        <!--END Owner Information-->
-                        <!--START Sole Proprietor Information-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="proprietorinfo">Sole Proprietor Information</h2>
-                        </div>
-                        <fieldset aria-labelledby="proprietorinfo">
-                            <div class="row">
-                                <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
-                                    <label for="first-name"><span class="weight600">&#42;</span>First name</label>
-                                    <input type="text" class="form-control" id="first-name" th:value="${owner.getOwnerSolpFirstName()}">
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
-                                    <label for="middle-name">Middle name</label>
-                                    <input type="text" class="form-control" id="middle-name" th:value="${owner.getOwnerSolpMiddleName()}">
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
-                                    <label for="last-name"><span class="weight600">&#42;</span>Last name</label>
-                                    <input type="text" class="form-control" id="last-name"  th:value="${owner.getOwnerSolpLastName()}">
-                                </div>
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="suffix">Suffix</label>
-                                    <select class="form-control" id="suffix" th:field="${owner.suffix}">
-                                        <option value="Select">Select</option>
-                                        <option value="Sr.">Sr.</option>
-                                        <option value="I">I</option>
-                                        <option value="II">II</option>
-                                        <option value="III">III</option>
-                                        <option value="IV">IV</option>
-                                        <option value="V">V</option>
-                                        <option value="VI">VI</option>
-                                        <option value="Jr.">Jr.</option>
-                                        <option value="VII">VII</option>
-                                        <option value="VIII">VIII</option>
-                                    </select>
-                                </div>
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="countryofcitizenship"><span class="weight600">&#42;</span>Country of citizenship</label>
-                                    <select class="form-control" id="countryofcitizenship" th:field="${owner.citizenShip}" >
-                                        <option value="">Select</option>
-                                        <option value="United States of America">United States of America</option>
-                                        <option value="Afghanistan">Afghanistan</option>
-                                        <option value="Albania">Albania</option>
-                                        <option value="Algeria">Algeria</option>
-                                        <option value="American Samoa">American Samoa</option>
-                                        <option value="Andorra">Andorra</option>
-                                        <option value="Angola">Angola</option>
-                                        <option value="Anguilla">Anguilla</option>
-                                        <option value="Antarctica">Antarctica</option>
-                                        <option value="Antigua and Barbuda">Antigua and Barbuda</option>
-                                        <option value="Argentina">Argentina</option>
-                                        <option value="Armenia">Armenia</option>
-                                        <option value="Aruba">Aruba</option>
-                                        <option value="Australia">Australia</option>
-                                        <option value="Austria">Austria</option>
-                                        <option value="Azerbaijan">Azerbaijan</option>
-                                        <option value="Bahamas">Bahamas</option>
-                                        <option value="Bahrain">Bahrain</option>
-                                        <option value="Bangladesh">Bangladesh</option>
-                                        <option value="Barbados">Barbados</option>
-                                        <option value="Belarus">Belarus</option>
-                                        <option value="Belgium">Belgium</option>
-                                        <option value="Belize">Belize</option>
-                                        <option value="Benin">Benin</option>
-                                        <option value="Bermuda">Bermuda</option>
-                                        <option value="Bhutan">Bhutan</option>
-                                        <option value="Bolivia">Bolivia</option>
-                                        <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
-                                        <option value="Botswana">Botswana</option>
-                                        <option value="Bouvet Island">Bouvet Island</option>
-                                        <option value="Brazil">Brazil</option>
-                                        <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
-                                        <option value="Brunei Darussalam">Brunei Darussalam</option>
-                                        <option value="Bulgaria">Bulgaria</option>
-                                        <option value="Burkina Faso">Burkina Faso</option>
-                                        <option value="Burundi">Burundi</option>
-                                        <option value="Canada">Canada</option>
-                                        <option value="Cambodia">Cambodia</option>
-                                        <option value="Cameroon">Cameroon</option>
-                                        <option value="Cape Verde">Cape Verde</option>
-                                        <option value="Cayman Islands">Cayman Islands</option>
-                                        <option value="Central African Republic">Central African Republic</option>
-                                        <option value="Chad">Chad</option>
-                                        <option value="Chile">Chile</option>
-                                        <option value="China">China</option>
-                                        <option value="Christmas Island">Christmas Island</option>
-                                        <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
-                                        <option value="Colombia">Colombia</option>
-                                        <option value="Comoros">Comoros</option>
-                                        <option value="Congo">Congo</option>
-                                        <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
-                                        <option value="Cook Islands">Cook Islands</option>
-                                        <option value="Costa Rica">Costa Rica</option>
-                                        <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
-                                        <option value="Croatia">Croatia</option>
-                                        <option value="Cuba">Cuba</option>
-                                        <option value="Cyprus">Cyprus</option>
-                                        <option value="Czech Republic">Czech Republic</option>
-                                        <option value="Denmark">Denmark</option>
-                                        <option value="Djibouti">Djibouti</option>
-                                        <option value="Dominica">Dominica</option>
-                                        <option value="Dominican Republic">Dominican Republic</option>
-                                        <option value="East Timor">East Timor</option>
-                                        <option value="Ecuador">Ecuador</option>
-                                        <option value="Egypt">Egypt</option>
-                                        <option value="El Salvador">El Salvador</option>
-                                        <option value="Equatorial Guinea">Equatorial Guinea</option>
-                                        <option value="Eritrea">Eritrea</option>
-                                        <option value="Estonia">Estonia</option>
-                                        <option value="Ethiopia">Ethiopia</option>
-                                        <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
-                                        <option value="Faroe Islands">Faroe Islands</option>
-                                        <option value="Fiji">Fiji</option>
-                                        <option value="Finland">Finland</option>
-                                        <option value="France">France</option>
-                                        <option value="French Guiana">French Guiana</option>
-                                        <option value="French Polynesia">French Polynesia</option>
-                                        <option value="French Southern Territories">French Southern Territories</option>
-                                        <option value="Gabon">Gabon</option>
-                                        <option value="Gambia">Gambia</option>
-                                        <option value="Georgia">Georgia</option>
-                                        <option value="Germany">Germany</option>
-                                        <option value="Ghana">Ghana</option>
-                                        <option value="Gibraltar">Gibraltar</option>
-                                        <option value="Greece">Greece</option>
-                                        <option value="Greenland">Greenland</option>
-                                        <option value="Grenada">Grenada</option>
-                                        <option value="Guadeloupe">Guadeloupe</option>
-                                        <option value="Guam">Guam</option>
-                                        <option value="Guatemala">Guatemala</option>
-                                        <option value="Guinea">Guinea</option>
-                                        <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
-                                        <option value="Guyana">Guyana</option>
-                                        <option value="Haiti">Haiti</option>
-                                        <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
-                                        <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
-                                        <option value="Honduras">Honduras</option>
-                                        <option value="Hong Kong">Hong Kong</option>
-                                        <option value="Hungary">Hungary</option>
-                                        <option value="Iceland">Iceland</option>
-                                        <option value="India">India</option>
-                                        <option value="Indonesia">Indonesia</option>
-                                        <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
-                                        <option value="Iraq">Iraq</option>
-                                        <option value="Ireland">Ireland</option>
-                                        <option value="Israel">Israel</option>
-                                        <option value="Italy">Italy</option>
-                                        <option value="Jamaica">Jamaica</option>
-                                        <option value="Japan">Japan</option>
-                                        <option value="Jordan">Jordan</option>
-                                        <option value="Kazakstan">Kazakstan</option>
-                                        <option value="Kenya">Kenya</option>
-                                        <option value="Kiribati">Kiribati</option>
-                                        <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
-                                        <option value="Korea, Republic of">Korea, Republic of</option>
-                                        <option value="Kuwait">Kuwait</option>
-                                        <option value="Kyrgyzstan">Kyrgyzstan</option>
-                                        <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
-                                        <option value="Latvia">Latvia</option>
-                                        <option value="Lebanon">Lebanon</option>
-                                        <option value="Lesotho">Lesotho</option>
-                                        <option value="Liberia">Liberia</option>
-                                        <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
-                                        <option value="Liechtenstein">Liechtenstein</option>
-                                        <option value="Lithuania">Lithuania</option>
-                                        <option value="Luxembourg">Luxembourg</option>
-                                        <option value="Macau">Macau</option>
-                                        <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
-                                        <option value="Madagascar">Madagascar</option>
-                                        <option value="Malawi">Malawi</option>
-                                        <option value="Malaysia">Malaysia</option>
-                                        <option value="Maldives">Maldives</option>
-                                        <option value="Mali">Mali</option>
-                                        <option value="Malta">Malta</option>
-                                        <option value="Marshall Islands">Marshall Islands</option>
-                                        <option value="Martinique">Martinique</option>
-                                        <option value="Mauritania">Mauritania</option>
-                                        <option value="Mauritius">Mauritius</option>
-                                        <option value="Mayotte">Mayotte</option>
-                                        <option value="Mexico">Mexico</option>
-                                        <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
-                                        <option value="Moldova, Republic of">Moldova, Republic of</option>
-                                        <option value="Monaco">Monaco</option>
-                                        <option value="Mongolia">Mongolia</option>
-                                        <option value="Montserrat">Montserrat</option>
-                                        <option value="Morocco">Morocco</option>
-                                        <option value="Mozambique">Mozambique</option>
-                                        <option value="Myanmar">Myanmar</option>
-                                        <option value="Namibia">Namibia</option>
-                                        <option value="Nauru">Nauru</option>
-                                        <option value="Nepal">Nepal</option>
-                                        <option value="Netherlands">Netherlands</option>
-                                        <option value="Netherlands Antilles">Netherlands Antilles</option>
-                                        <option value="New Caledonia">New Caledonia</option>
-                                        <option value="New Zealand">New Zealand</option>
-                                        <option value="Nicaragua">Nicaragua</option>
-                                        <option value="Niger">Niger</option>
-                                        <option value="Nigeria">Nigeria</option>
-                                        <option value="Niue">Niue</option>
-                                        <option value="Norfolk Island">Norfolk Island</option>
-                                        <option value="Northern Mariana Islands">Northern Mariana Islands</option>
-                                        <option value="Norway">Norway</option>
-                                        <option value="Oman">Oman</option>
-                                        <option value="Pakistan">Pakistan</option>
-                                        <option value="Palau">Palau</option>
-                                        <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
-                                        <option value="Panama">Panama</option>
-                                        <option value="Papua New Guinea">Papua New Guinea</option>
-                                        <option value="Paraguay">Paraguay</option>
-                                        <option value="Peru">Peru</option>
-                                        <option value="Philippines">Philippines</option>
-                                        <option value="Pitcairn">Pitcairn</option>
-                                        <option value="Poland">Poland</option>
-                                        <option value="Portugal">Portugal</option>
-                                        <option value="Puerto Rico">Puerto Rico</option>
-                                        <option value="Qatar">Qatar</option>
-                                        <option value="Reunion">Reunion</option>
-                                        <option value="Romania">Romania</option>
-                                        <option value="Russian Federation">Russian Federation</option>
-                                        <option value="Rwanda">Rwanda</option>
-                                        <option value="Saint Helena">Saint Helena</option>
-                                        <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
-                                        <option value="Saint Lucia">Saint Lucia</option>
-                                        <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
-                                        <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
-                                        <option value="Samoa">Samoa</option>
-                                        <option value="San Marino">San Marino</option>
-                                        <option value="Sao Tome and Principe">Sao Tome and Principe</option>
-                                        <option value="Saudi Arabia">Saudi Arabia</option>
-                                        <option value="Senegal">Senegal</option>
-                                        <option value="Seychelles">Seychelles</option>
-                                        <option value="Sierra Leone">Sierra Leone</option>
-                                        <option value="Singapore">Singapore</option>
-                                        <option value="Slovakia">Slovakia</option>
-                                        <option value="Slovenia">Slovenia</option>
-                                        <option value="Solomon Islands">Solomon Islands</option>
-                                        <option value="Somalia">Somalia</option>
-                                        <option value="South Africa">South Africa</option>
-                                        <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
-                                        <option value="Spain">Spain</option>
-                                        <option value="Sri Lanka">Sri Lanka</option>
-                                        <option value="Sudan">Sudan</option>
-                                        <option value="Suriname">Suriname</option>
-                                        <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
-                                        <option value="Swaziland">Swaziland</option>
-                                        <option value="Sweden">Sweden</option>
-                                        <option value="Switzerland">Switzerland</option>
-                                        <option value="Syrian Arab Republic">Syrian Arab Republic</option>
-                                        <option value="Taiwan">Taiwan</option>
-                                        <option value="Tajikistan">Tajikistan</option>
-                                        <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
-                                        <option value="Thailand">Thailand</option>
-                                        <option value="Togo">Togo</option>
-                                        <option value="Tokelau">Tokelau</option>
-                                        <option value="Tonga">Tonga</option>
-                                        <option value="Trinidad and Tobago">Trinidad and Tobago</option>
-                                        <option value="Tunisia">Tunisia</option>
-                                        <option value="Turkey">Turkey</option>
-                                        <option value="Turkmenistan">Turkmenistan</option>
-                                        <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
-                                        <option value="Tuvalu">Tuvalu</option>
-                                        <option value="Uganda">Uganda</option>
-                                        <option value="Ukraine">Ukraine</option>
-                                        <option value="United Arab Emirates">United Arab Emirates</option>
-                                        <option value="United Kingdom">United Kingdom</option>
-                                        <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
-                                        <option value="Uruguay">Uruguay</option>
-                                        <option value="Uzbekistan">Uzbekistan</option>
-                                        <option value="Vanuatu">Vanuatu</option>
-                                        <option value="Venezuela">Venezuela</option>
-                                        <option value="Viet Nam">Viet Nam</option>
-                                        <option value="Virgin Islands, British">Virgin Islands, British</option>
-                                        <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
-                                        <option value="Wallis and Futuna">Wallis and Futuna</option>
-                                        <option value="Western Sahara">Western Sahara</option>
-                                        <option value="Yemen">Yemen</option>
-                                        <option value="Yugoslavia">Yugoslavia</option>
-                                        <option value="Zambia">Zambia</option>
-                                        <option value="Zimbabwe">Zimbabwe</option>
-                                        <option value="Unknown">Unknown</option>
-                                    </select>
+                                <div class="col-xs-6">
+                                    <h1 style="margin-left: 15px;">Edit Owner Information</h1>
                                 </div>
                             </div>
-                        </fieldset>
-                        <!--END Sole Proprietor Information Form-->
-                        <!--START Owner Address Information Form-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="addressinfo">Owner Address Information</h2>
-                        </div>
-                        <fieldset aria-labelledby="addressinfo">
-                            <div class="row">
-                                <div class="form-group form-group-md col-md-12 col-lg-7">
-                                    <label for="OwnerAddressCountry"><span class="weight600">&#42;</span>Country / U.S. territory</label>
-                                    <select class="form-control" id="OwnerAddressCountry" name="territory"  th:field="${owner.country}">
-                                        <option value="">Select</option>
-                                        <option value="United States of America">United States of America</option>
-                                        <option value="Afghanistan">Afghanistan</option>
-                                        <option value="Albania">Albania</option>
-                                        <option value="Algeria">Algeria</option>
-                                        <option value="American Samoa">American Samoa</option>
-                                        <option value="Andorra">Andorra</option>
-                                        <option value="Angola">Angola</option>
-                                        <option value="Anguilla">Anguilla</option>
-                                        <option value="Antarctica">Antarctica</option>
-                                        <option value="Antigua and Barbuda">Antigua and Barbuda</option>
-                                        <option value="Argentina">Argentina</option>
-                                        <option value="Armenia">Armenia</option>
-                                        <option value="Aruba">Aruba</option>
-                                        <option value="Australia">Australia</option>
-                                        <option value="Austria">Austria</option>
-                                        <option value="Azerbaijan">Azerbaijan</option>
-                                        <option value="Bahamas">Bahamas</option>
-                                        <option value="Bahrain">Bahrain</option>
-                                        <option value="Bangladesh">Bangladesh</option>
-                                        <option value="Barbados">Barbados</option>
-                                        <option value="Belarus">Belarus</option>
-                                        <option value="Belgium">Belgium</option>
-                                        <option value="Belize">Belize</option>
-                                        <option value="Benin">Benin</option>
-                                        <option value="Bermuda">Bermuda</option>
-                                        <option value="Bhutan">Bhutan</option>
-                                        <option value="Bolivia">Bolivia</option>
-                                        <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
-                                        <option value="Botswana">Botswana</option>
-                                        <option value="Bouvet Island">Bouvet Island</option>
-                                        <option value="Brazil">Brazil</option>
-                                        <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
-                                        <option value="Brunei Darussalam">Brunei Darussalam</option>
-                                        <option value="Bulgaria">Bulgaria</option>
-                                        <option value="Burkina Faso">Burkina Faso</option>
-                                        <option value="Burundi">Burundi</option>
-                                        <option value="Canada">Canada</option>
-                                        <option value="Cambodia">Cambodia</option>
-                                        <option value="Cameroon">Cameroon</option>
-                                        <option value="Cape Verde">Cape Verde</option>
-                                        <option value="Cayman Islands">Cayman Islands</option>
-                                        <option value="Central African Republic">Central African Republic</option>
-                                        <option value="Chad">Chad</option>
-                                        <option value="Chile">Chile</option>
-                                        <option value="China">China</option>
-                                        <option value="Christmas Island">Christmas Island</option>
-                                        <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
-                                        <option value="Colombia">Colombia</option>
-                                        <option value="Comoros">Comoros</option>
-                                        <option value="Congo">Congo</option>
-                                        <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
-                                        <option value="Cook Islands">Cook Islands</option>
-                                        <option value="Costa Rica">Costa Rica</option>
-                                        <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
-                                        <option value="Croatia">Croatia</option>
-                                        <option value="Cuba">Cuba</option>
-                                        <option value="Cyprus">Cyprus</option>
-                                        <option value="Czech Republic">Czech Republic</option>
-                                        <option value="Denmark">Denmark</option>
-                                        <option value="Djibouti">Djibouti</option>
-                                        <option value="Dominica">Dominica</option>
-                                        <option value="Dominican Republic">Dominican Republic</option>
-                                        <option value="East Timor">East Timor</option>
-                                        <option value="Ecuador">Ecuador</option>
-                                        <option value="Egypt">Egypt</option>
-                                        <option value="El Salvador">El Salvador</option>
-                                        <option value="Equatorial Guinea">Equatorial Guinea</option>
-                                        <option value="Eritrea">Eritrea</option>
-                                        <option value="Estonia">Estonia</option>
-                                        <option value="Ethiopia">Ethiopia</option>
-                                        <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
-                                        <option value="Faroe Islands">Faroe Islands</option>
-                                        <option value="Fiji">Fiji</option>
-                                        <option value="Finland">Finland</option>
-                                        <option value="France">France</option>
-                                        <option value="French Guiana">French Guiana</option>
-                                        <option value="French Polynesia">French Polynesia</option>
-                                        <option value="French Southern Territories">French Southern Territories</option>
-                                        <option value="Gabon">Gabon</option>
-                                        <option value="Gambia">Gambia</option>
-                                        <option value="Georgia">Georgia</option>
-                                        <option value="Germany">Germany</option>
-                                        <option value="Ghana">Ghana</option>
-                                        <option value="Gibraltar">Gibraltar</option>
-                                        <option value="Greece">Greece</option>
-                                        <option value="Greenland">Greenland</option>
-                                        <option value="Grenada">Grenada</option>
-                                        <option value="Guadeloupe">Guadeloupe</option>
-                                        <option value="Guam">Guam</option>
-                                        <option value="Guatemala">Guatemala</option>
-                                        <option value="Guinea">Guinea</option>
-                                        <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
-                                        <option value="Guyana">Guyana</option>
-                                        <option value="Haiti">Haiti</option>
-                                        <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
-                                        <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
-                                        <option value="Honduras">Honduras</option>
-                                        <option value="Hong Kong">Hong Kong</option>
-                                        <option value="Hungary">Hungary</option>
-                                        <option value="Iceland">Iceland</option>
-                                        <option value="India">India</option>
-                                        <option value="Indonesia">Indonesia</option>
-                                        <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
-                                        <option value="Iraq">Iraq</option>
-                                        <option value="Ireland">Ireland</option>
-                                        <option value="Israel">Israel</option>
-                                        <option value="Italy">Italy</option>
-                                        <option value="Jamaica">Jamaica</option>
-                                        <option value="Japan">Japan</option>
-                                        <option value="Jordan">Jordan</option>
-                                        <option value="Kazakstan">Kazakstan</option>
-                                        <option value="Kenya">Kenya</option>
-                                        <option value="Kiribati">Kiribati</option>
-                                        <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
-                                        <option value="Korea, Republic of">Korea, Republic of</option>
-                                        <option value="Kuwait">Kuwait</option>
-                                        <option value="Kyrgyzstan">Kyrgyzstan</option>
-                                        <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
-                                        <option value="Latvia">Latvia</option>
-                                        <option value="Lebanon">Lebanon</option>
-                                        <option value="Lesotho">Lesotho</option>
-                                        <option value="Liberia">Liberia</option>
-                                        <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
-                                        <option value="Liechtenstein">Liechtenstein</option>
-                                        <option value="Lithuania">Lithuania</option>
-                                        <option value="Luxembourg">Luxembourg</option>
-                                        <option value="Macau">Macau</option>
-                                        <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
-                                        <option value="Madagascar">Madagascar</option>
-                                        <option value="Malawi">Malawi</option>
-                                        <option value="Malaysia">Malaysia</option>
-                                        <option value="Maldives">Maldives</option>
-                                        <option value="Mali">Mali</option>
-                                        <option value="Malta">Malta</option>
-                                        <option value="Marshall Islands">Marshall Islands</option>
-                                        <option value="Martinique">Martinique</option>
-                                        <option value="Mauritania">Mauritania</option>
-                                        <option value="Mauritius">Mauritius</option>
-                                        <option value="Mayotte">Mayotte</option>
-                                        <option value="Mexico">Mexico</option>
-                                        <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
-                                        <option value="Moldova, Republic of">Moldova, Republic of</option>
-                                        <option value="Monaco">Monaco</option>
-                                        <option value="Mongolia">Mongolia</option>
-                                        <option value="Montserrat">Montserrat</option>
-                                        <option value="Morocco">Morocco</option>
-                                        <option value="Mozambique">Mozambique</option>
-                                        <option value="Myanmar">Myanmar</option>
-                                        <option value="Namibia">Namibia</option>
-                                        <option value="Nauru">Nauru</option>
-                                        <option value="Nepal">Nepal</option>
-                                        <option value="Netherlands">Netherlands</option>
-                                        <option value="Netherlands Antilles">Netherlands Antilles</option>
-                                        <option value="New Caledonia">New Caledonia</option>
-                                        <option value="New Zealand">New Zealand</option>
-                                        <option value="Nicaragua">Nicaragua</option>
-                                        <option value="Niger">Niger</option>
-                                        <option value="Nigeria">Nigeria</option>
-                                        <option value="Niue">Niue</option>
-                                        <option value="Norfolk Island">Norfolk Island</option>
-                                        <option value="Northern Mariana Islands">Northern Mariana Islands</option>
-                                        <option value="Norway">Norway</option>
-                                        <option value="Oman">Oman</option>
-                                        <option value="Pakistan">Pakistan</option>
-                                        <option value="Palau">Palau</option>
-                                        <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
-                                        <option value="Panama">Panama</option>
-                                        <option value="Papua New Guinea">Papua New Guinea</option>
-                                        <option value="Paraguay">Paraguay</option>
-                                        <option value="Peru">Peru</option>
-                                        <option value="Philippines">Philippines</option>
-                                        <option value="Pitcairn">Pitcairn</option>
-                                        <option value="Poland">Poland</option>
-                                        <option value="Portugal">Portugal</option>
-                                        <option value="Puerto Rico">Puerto Rico</option>
-                                        <option value="Qatar">Qatar</option>
-                                        <option value="Reunion">Reunion</option>
-                                        <option value="Romania">Romania</option>
-                                        <option value="Russian Federation">Russian Federation</option>
-                                        <option value="Rwanda">Rwanda</option>
-                                        <option value="Saint Helena">Saint Helena</option>
-                                        <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
-                                        <option value="Saint Lucia">Saint Lucia</option>
-                                        <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
-                                        <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
-                                        <option value="Samoa">Samoa</option>
-                                        <option value="San Marino">San Marino</option>
-                                        <option value="Sao Tome and Principe">Sao Tome and Principe</option>
-                                        <option value="Saudi Arabia">Saudi Arabia</option>
-                                        <option value="Senegal">Senegal</option>
-                                        <option value="Seychelles">Seychelles</option>
-                                        <option value="Sierra Leone">Sierra Leone</option>
-                                        <option value="Singapore">Singapore</option>
-                                        <option value="Slovakia">Slovakia</option>
-                                        <option value="Slovenia">Slovenia</option>
-                                        <option value="Solomon Islands">Solomon Islands</option>
-                                        <option value="Somalia">Somalia</option>
-                                        <option value="South Africa">South Africa</option>
-                                        <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
-                                        <option value="Spain">Spain</option>
-                                        <option value="Sri Lanka">Sri Lanka</option>
-                                        <option value="Sudan">Sudan</option>
-                                        <option value="Suriname">Suriname</option>
-                                        <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
-                                        <option value="Swaziland">Swaziland</option>
-                                        <option value="Sweden">Sweden</option>
-                                        <option value="Switzerland">Switzerland</option>
-                                        <option value="Syrian Arab Republic">Syrian Arab Republic</option>
-                                        <option value="Taiwan">Taiwan</option>
-                                        <option value="Tajikistan">Tajikistan</option>
-                                        <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
-                                        <option value="Thailand">Thailand</option>
-                                        <option value="Togo">Togo</option>
-                                        <option value="Tokelau">Tokelau</option>
-                                        <option value="Tonga">Tonga</option>
-                                        <option value="Trinidad and Tobago">Trinidad and Tobago</option>
-                                        <option value="Tunisia">Tunisia</option>
-                                        <option value="Turkey">Turkey</option>
-                                        <option value="Turkmenistan">Turkmenistan</option>
-                                        <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
-                                        <option value="Tuvalu">Tuvalu</option>
-                                        <option value="Uganda">Uganda</option>
-                                        <option value="Ukraine">Ukraine</option>
-                                        <option value="United Arab Emirates">United Arab Emirates</option>
-                                        <option value="United Kingdom">United Kingdom</option>
-                                        <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
-                                        <option value="Uruguay">Uruguay</option>
-                                        <option value="Uzbekistan">Uzbekistan</option>
-                                        <option value="Vanuatu">Vanuatu</option>
-                                        <option value="Venezuela">Venezuela</option>
-                                        <option value="Viet Nam">Viet Nam</option>
-                                        <option value="Virgin Islands, British">Virgin Islands, British</option>
-                                        <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
-                                        <option value="Wallis and Futuna">Wallis and Futuna</option>
-                                        <option value="Western Sahara">Western Sahara</option>
-                                        <option value="Yemen">Yemen</option>
-                                        <option value="Yugoslavia">Yugoslavia</option>
-                                        <option value="Zambia">Zambia</option>
-                                        <option value="Zimbabwe">Zimbabwe</option>
-                                        <option value="Unknown">Unknown</option>
-                                    </select>
+                            <div class="col-xs-12 text-left">
+                                <!--START Owner Information Form-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="ownerinfo">Owner Information</h2>
                                 </div>
-                                <div class="form-group form-group-md col-md-12 col-lg-9">
-                                    <label for="ownerAddress1"><span class="weight600">&#42;</span>Address line 1</label>
-                                    <input type="text" class="form-control" id="ownerAddress1"  th:value="${owner.address1}">
-                                </div>
-                                <div class="form-group form-group-md col-md-12 col-lg-9">
-                                    <label for="addressline2">Address line 2</label>
-                                    <input type="text" class="form-control" id="addressline2" >
-                                </div>
-                                <div class="form-group form-group-md col-md-12 col-lg-9">
-                                    <label for="addressline3">Address line 3</label>
-                                    <input type="text" class="form-control" id="addressline3" >
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                    <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
-                                    <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}">
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                    <label for="ownerState"><span class="weight600">&#42;</span>State/Province/Territory</label>
-                                    <select class="form-control" id="ownerState" th:field="${owner.state}" required>
-                                        <option value="">Select</option>
-                                        <option value="Alabama">Alabama</option>
-                                        <option value="Alaska">Alaska</option>
-                                        <option value="Arizona">Arizona</option>
-                                        <option value="Arkansas">Arkansas</option>
-                                        <option value="California">California</option>
-                                        <option value="Colorado">Colorado</option>
-                                        <option value="Connecticut">Connecticut</option>
-                                        <option value="Delaware">Delaware</option>
-                                        <option value="District of Columbia">District of Columbia</option>
-                                        <option value="Florida">Florida</option>
-                                        <option value="Georgia">Georgia</option>
-                                        <option value="Hawaii">Hawaii</option>
-                                        <option value="Idaho">Idaho</option>
-                                        <option value="Illinois">Illinois</option>
-                                        <option value="Indiana">Indiana</option>
-                                        <option value="Iowa">Iowa</option>
-                                        <option value="Kansas">Kansas</option>
-                                        <option value="Kentucky">Kentucky</option>
-                                        <option value="Louisiana">Louisiana</option>
-                                        <option value="Maine">Maine</option>
-                                        <option value="Maryland">Maryland</option>
-                                        <option value="Massachusetts">Massachusetts</option>
-                                        <option value="Michigan">Michigan</option>
-                                        <option value="Minnesota">Minnesota</option>
-                                        <option value="Mississippi">Mississippi</option>
-                                        <option value="Missouri">Missouri</option>
-                                        <option value="Montana">Montana</option>
-                                        <option value="Nebraska">Nebraska</option>
-                                        <option value="Nevada">Nevada</option>
-                                        <option value="New Hampshire">New Hampshire</option>
-                                        <option value="New Jersey">New Jersey</option>
-                                        <option value="New Mexico">New Mexico</option>
-                                        <option value="New York">New York</option>
-                                        <option value="North Carolina">North Carolina</option>
-                                        <option value="North Dakota">North Dakota</option>
-                                        <option value="Ohio">Ohio</option>
-                                        <option value="Oklahoma">Oklahoma</option>
-                                        <option value="Oregon">Oregon</option>
-                                        <option value="Pennsylvania">Pennsylvania</option>
-                                        <option value="Rhode Island">Rhode Island</option>
-                                        <option value="South Carolina">South Carolina</option>
-                                        <option value="South Dakota">South Dakota</option>
-                                        <option value="Tennessee">Tennessee</option>
-                                        <option value="Texas">Texas</option>
-                                        <option value="Utah">Utah</option>
-                                        <option value="Vermont">Vermont</option>
-                                        <option value="Virginia">Virginia</option>
-                                        <option value="Washington">Washington</option>
-                                        <option value="West Virginia">West Virginia</option>
-                                        <option value="Wisconsin">Wisconsin</option>
-                                        <option value="Wyoming">Wyoming</option>
-                                    </select>
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-5">
-                                    <label for="ownerZipcode"><span class="weight600">&#42;</span>Zip code/Postal code</label>
-                                    <input type="text" class="form-control" id="ownerZipcode" placeholder="" th:value="${owner.zipcode}">
-                                </div>
-                            </div>
-                        </fieldset>
-                        <!--END Owner Address Information Form-->
-                        <!--START Additional Information Form-->
-                        <div class="card-text">
-                            <h2 class="card-title weight600" id="additionalinfo">Additional Information</h2>
-                        </div>
-                        <fieldset aria-labelledby="additionalinfo">
-                            <div class="row">
-                                <div class="form-group form-group-md col-xs-12 col-md-6">
-                                    <label for="ownerEmail"><span class="weight600">&#42;</span>Email address <a href="#" data-toggle="tooltip" title="The USPTO will use this email address to send correspondence regarding this application or registration. It is critical to ensure this email address is current." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
-                                    <input type="text" class="form-control" id="ownerEmail" th:value="${owner.email}">
-                                </div>
-                                <div class="form-group form-group-md col-xs-12 col-md-6">
-                                    <label for="webaddress">Website address</label>
-                                    <input type="text" class="form-control" id="webaddress" th:value="${owner.webSiteURL}">
-                                </div>
-                                <div class="row">
-                                    <div class="col-xs-12">
-                                        <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-4">
-                                            <label for="phonenumbertype">Phone type</label>
-                                            <select class="form-control" id="phonenumbertype" name="phonenumbertype">
-                                                <option value="Type">Type</option>
-                                                <option value="Cell">Cell</option>
-                                                <option value="Home">Home</option>
-                                                <option value="Work">Work</option>
-                                                <option value="Fax">Fax</option>
+                                <fieldset aria-labelledby="ownerinfo">
+                                    <div class="row">
+                                        <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                            <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
+                                            <input type="text" class="form-control"  id="ownername"  th:value="${owner.getOwnerName()}">
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                            <label for="stateoforg">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                            <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}" >
+                                                <option value="">Select</option>
+                                                <option value="Alabama">Alabama</option>
+                                                <option value="Alaska">Alaska</option>
+                                                <option value="Arizona">Arizona</option>
+                                                <option value="Arkansas">Arkansas</option>
+                                                <option value="California">California</option>
+                                                <option value="Colorado">Colorado</option>
+                                                <option value="Connecticut">Connecticut</option>
+                                                <option value="Delaware">Delaware</option>
+                                                <option value="District of Columbia">District of Columbia</option>
+                                                <option value="Florida">Florida</option>
+                                                <option value="Georgia">Georgia</option>
+                                                <option value="Hawaii">Hawaii</option>
+                                                <option value="Idaho">Idaho</option>
+                                                <option value="Illinois">Illinois</option>
+                                                <option value="Indiana">Indiana</option>
+                                                <option value="Iowa">Iowa</option>
+                                                <option value="Kansas">Kansas</option>
+                                                <option value="Kentucky">Kentucky</option>
+                                                <option value="Louisiana">Louisiana</option>
+                                                <option value="Maine">Maine</option>
+                                                <option value="Maryland">Maryland</option>
+                                                <option value="Massachusetts">Massachusetts</option>
+                                                <option value="Michigan">Michigan</option>
+                                                <option value="Minnesota">Minnesota</option>
+                                                <option value="Mississippi">Mississippi</option>
+                                                <option value="Missouri">Missouri</option>
+                                                <option value="Montana">Montana</option>
+                                                <option value="Nebraska">Nebraska</option>
+                                                <option value="Nevada">Nevada</option>
+                                                <option value="New Hampshire">New Hampshire</option>
+                                                <option value="New Jersey">New Jersey</option>
+                                                <option value="New Mexico">New Mexico</option>
+                                                <option value="New York">New York</option>
+                                                <option value="North Carolina">North Carolina</option>
+                                                <option value="North Dakota">North Dakota</option>
+                                                <option value="Ohio">Ohio</option>
+                                                <option value="Oklahoma">Oklahoma</option>
+                                                <option value="Oregon">Oregon</option>
+                                                <option value="Pennsylvania">Pennsylvania</option>
+                                                <option value="Rhode Island">Rhode Island</option>
+                                                <option value="South Carolina">South Carolina</option>
+                                                <option value="South Dakota">South Dakota</option>
+                                                <option value="Tennessee">Tennessee</option>
+                                                <option value="Texas">Texas</option>
+                                                <option value="Utah">Utah</option>
+                                                <option value="Vermont">Vermont</option>
+                                                <option value="Virginia">Virginia</option>
+                                                <option value="Washington">Washington</option>
+                                                <option value="West Virginia">West Virginia</option>
+                                                <option value="Wisconsin">Wisconsin</option>
+                                                <option value="Wyoming">Wyoming</option>
                                             </select>
                                         </div>
-                                        <div class="form-group form-group-md col-xs-12 col-md-6 col-lg-6">
-                                            <label for="phone">Phone number</label>
-                                            <input type="text" class="form-control" id="phone" th:value="${owner.primaryPhonenumber}">
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                            <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                            <select class="form-control" id="additional-name-type"  th:field="${owner.ownerType}">
+                                                <option value="">Select</option>
+                                                <option value="DBA">Doing Business As (DBA)</option>
+                                                <option value="TA">Trading As (TA)</option>
+                                                <option value="AKA">Also Known As (AKA)</option>
+                                                <option value="Formerly">Formerly</option>
+                                            </select>
                                         </div>
-                                        <div class="form-group form-group-md col-xs-12 col-md-2 col-lg-2">
-                                            <label for="extension">Ext.</label>
-                                            <input type="text" class="form-control" id="extension">
+
+                                        <th:block  th:if="${owner.isAlternameSet() == true}">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype">
+                                                <label for="nameoftype">Name</label>
+                                                <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
+                                            </div>
+
+                                        </th:block>
+
+                                        <th:block  th:if="${owner.isAlternameSet() == false}">
+                                            <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype" style="display: none;">
+                                                <label for="nameoftype">Name</label>
+                                                <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
+                                            </div>
+
+                                        </th:block>
+
+
+
+                                    </div>
+                                </fieldset>
+                                <!--END Owner Information-->
+                                <!--START Sole Proprietor Information-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="proprietorinfo">Sole Proprietor Information</h2>
+                                </div>
+                                <fieldset aria-labelledby="proprietorinfo">
+                                    <div class="row">
+                                        <div class="form-group form-group-md col-xs-12 col-md-8 col-lg-4">
+                                            <label for="first-name"><span class="weight600">&#42;</span>First name</label>
+                                            <input type="text" class="form-control" id="first-name" th:value="${owner.getOwnerSolpFirstName()}">
                                         </div>
+                                        <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-3">
+                                            <label for="middle-name">Middle name</label>
+                                            <input type="text" class="form-control" id="middle-name" th:value="${owner.getOwnerSolpMiddleName()}">
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-md-12 col-lg-5">
+                                            <label for="last-name"><span class="weight600">&#42;</span>Last name</label>
+                                            <input type="text" class="form-control" id="last-name"  th:value="${owner.getOwnerSolpLastName()}">
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
+                                            <label for="suffix">Suffix</label>
+                                            <select class="form-control" id="suffix" th:field="${owner.suffix}">
+                                                <option value="Select">Select</option>
+                                                <option value="Sr.">Sr.</option>
+                                                <option value="I">I</option>
+                                                <option value="II">II</option>
+                                                <option value="III">III</option>
+                                                <option value="IV">IV</option>
+                                                <option value="V">V</option>
+                                                <option value="VI">VI</option>
+                                                <option value="Jr.">Jr.</option>
+                                                <option value="VII">VII</option>
+                                                <option value="VIII">VIII</option>
+                                            </select>
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
+                                            <label for="countryofcitizenship">Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                            <select class="form-control" id="countryofcitizenship" th:field="${owner.citizenShip}" >
+                                                <option value="">Select</option>
+                                                <option value="United States of America">United States of America</option>
+                                                <option value="Afghanistan">Afghanistan</option>
+                                                <option value="Albania">Albania</option>
+                                                <option value="Algeria">Algeria</option>
+                                                <option value="American Samoa">American Samoa</option>
+                                                <option value="Andorra">Andorra</option>
+                                                <option value="Angola">Angola</option>
+                                                <option value="Anguilla">Anguilla</option>
+                                                <option value="Antarctica">Antarctica</option>
+                                                <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+                                                <option value="Argentina">Argentina</option>
+                                                <option value="Armenia">Armenia</option>
+                                                <option value="Aruba">Aruba</option>
+                                                <option value="Australia">Australia</option>
+                                                <option value="Austria">Austria</option>
+                                                <option value="Azerbaijan">Azerbaijan</option>
+                                                <option value="Bahamas">Bahamas</option>
+                                                <option value="Bahrain">Bahrain</option>
+                                                <option value="Bangladesh">Bangladesh</option>
+                                                <option value="Barbados">Barbados</option>
+                                                <option value="Belarus">Belarus</option>
+                                                <option value="Belgium">Belgium</option>
+                                                <option value="Belize">Belize</option>
+                                                <option value="Benin">Benin</option>
+                                                <option value="Bermuda">Bermuda</option>
+                                                <option value="Bhutan">Bhutan</option>
+                                                <option value="Bolivia">Bolivia</option>
+                                                <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+                                                <option value="Botswana">Botswana</option>
+                                                <option value="Bouvet Island">Bouvet Island</option>
+                                                <option value="Brazil">Brazil</option>
+                                                <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+                                                <option value="Brunei Darussalam">Brunei Darussalam</option>
+                                                <option value="Bulgaria">Bulgaria</option>
+                                                <option value="Burkina Faso">Burkina Faso</option>
+                                                <option value="Burundi">Burundi</option>
+                                                <option value="Canada">Canada</option>
+                                                <option value="Cambodia">Cambodia</option>
+                                                <option value="Cameroon">Cameroon</option>
+                                                <option value="Cape Verde">Cape Verde</option>
+                                                <option value="Cayman Islands">Cayman Islands</option>
+                                                <option value="Central African Republic">Central African Republic</option>
+                                                <option value="Chad">Chad</option>
+                                                <option value="Chile">Chile</option>
+                                                <option value="China">China</option>
+                                                <option value="Christmas Island">Christmas Island</option>
+                                                <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+                                                <option value="Colombia">Colombia</option>
+                                                <option value="Comoros">Comoros</option>
+                                                <option value="Congo">Congo</option>
+                                                <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
+                                                <option value="Cook Islands">Cook Islands</option>
+                                                <option value="Costa Rica">Costa Rica</option>
+                                                <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
+                                                <option value="Croatia">Croatia</option>
+                                                <option value="Cuba">Cuba</option>
+                                                <option value="Cyprus">Cyprus</option>
+                                                <option value="Czech Republic">Czech Republic</option>
+                                                <option value="Denmark">Denmark</option>
+                                                <option value="Djibouti">Djibouti</option>
+                                                <option value="Dominica">Dominica</option>
+                                                <option value="Dominican Republic">Dominican Republic</option>
+                                                <option value="East Timor">East Timor</option>
+                                                <option value="Ecuador">Ecuador</option>
+                                                <option value="Egypt">Egypt</option>
+                                                <option value="El Salvador">El Salvador</option>
+                                                <option value="Equatorial Guinea">Equatorial Guinea</option>
+                                                <option value="Eritrea">Eritrea</option>
+                                                <option value="Estonia">Estonia</option>
+                                                <option value="Ethiopia">Ethiopia</option>
+                                                <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+                                                <option value="Faroe Islands">Faroe Islands</option>
+                                                <option value="Fiji">Fiji</option>
+                                                <option value="Finland">Finland</option>
+                                                <option value="France">France</option>
+                                                <option value="French Guiana">French Guiana</option>
+                                                <option value="French Polynesia">French Polynesia</option>
+                                                <option value="French Southern Territories">French Southern Territories</option>
+                                                <option value="Gabon">Gabon</option>
+                                                <option value="Gambia">Gambia</option>
+                                                <option value="Georgia">Georgia</option>
+                                                <option value="Germany">Germany</option>
+                                                <option value="Ghana">Ghana</option>
+                                                <option value="Gibraltar">Gibraltar</option>
+                                                <option value="Greece">Greece</option>
+                                                <option value="Greenland">Greenland</option>
+                                                <option value="Grenada">Grenada</option>
+                                                <option value="Guadeloupe">Guadeloupe</option>
+                                                <option value="Guam">Guam</option>
+                                                <option value="Guatemala">Guatemala</option>
+                                                <option value="Guinea">Guinea</option>
+                                                <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
+                                                <option value="Guyana">Guyana</option>
+                                                <option value="Haiti">Haiti</option>
+                                                <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+                                                <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+                                                <option value="Honduras">Honduras</option>
+                                                <option value="Hong Kong">Hong Kong</option>
+                                                <option value="Hungary">Hungary</option>
+                                                <option value="Iceland">Iceland</option>
+                                                <option value="India">India</option>
+                                                <option value="Indonesia">Indonesia</option>
+                                                <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+                                                <option value="Iraq">Iraq</option>
+                                                <option value="Ireland">Ireland</option>
+                                                <option value="Israel">Israel</option>
+                                                <option value="Italy">Italy</option>
+                                                <option value="Jamaica">Jamaica</option>
+                                                <option value="Japan">Japan</option>
+                                                <option value="Jordan">Jordan</option>
+                                                <option value="Kazakstan">Kazakstan</option>
+                                                <option value="Kenya">Kenya</option>
+                                                <option value="Kiribati">Kiribati</option>
+                                                <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
+                                                <option value="Korea, Republic of">Korea, Republic of</option>
+                                                <option value="Kuwait">Kuwait</option>
+                                                <option value="Kyrgyzstan">Kyrgyzstan</option>
+                                                <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
+                                                <option value="Latvia">Latvia</option>
+                                                <option value="Lebanon">Lebanon</option>
+                                                <option value="Lesotho">Lesotho</option>
+                                                <option value="Liberia">Liberia</option>
+                                                <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
+                                                <option value="Liechtenstein">Liechtenstein</option>
+                                                <option value="Lithuania">Lithuania</option>
+                                                <option value="Luxembourg">Luxembourg</option>
+                                                <option value="Macau">Macau</option>
+                                                <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
+                                                <option value="Madagascar">Madagascar</option>
+                                                <option value="Malawi">Malawi</option>
+                                                <option value="Malaysia">Malaysia</option>
+                                                <option value="Maldives">Maldives</option>
+                                                <option value="Mali">Mali</option>
+                                                <option value="Malta">Malta</option>
+                                                <option value="Marshall Islands">Marshall Islands</option>
+                                                <option value="Martinique">Martinique</option>
+                                                <option value="Mauritania">Mauritania</option>
+                                                <option value="Mauritius">Mauritius</option>
+                                                <option value="Mayotte">Mayotte</option>
+                                                <option value="Mexico">Mexico</option>
+                                                <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+                                                <option value="Moldova, Republic of">Moldova, Republic of</option>
+                                                <option value="Monaco">Monaco</option>
+                                                <option value="Mongolia">Mongolia</option>
+                                                <option value="Montserrat">Montserrat</option>
+                                                <option value="Morocco">Morocco</option>
+                                                <option value="Mozambique">Mozambique</option>
+                                                <option value="Myanmar">Myanmar</option>
+                                                <option value="Namibia">Namibia</option>
+                                                <option value="Nauru">Nauru</option>
+                                                <option value="Nepal">Nepal</option>
+                                                <option value="Netherlands">Netherlands</option>
+                                                <option value="Netherlands Antilles">Netherlands Antilles</option>
+                                                <option value="New Caledonia">New Caledonia</option>
+                                                <option value="New Zealand">New Zealand</option>
+                                                <option value="Nicaragua">Nicaragua</option>
+                                                <option value="Niger">Niger</option>
+                                                <option value="Nigeria">Nigeria</option>
+                                                <option value="Niue">Niue</option>
+                                                <option value="Norfolk Island">Norfolk Island</option>
+                                                <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+                                                <option value="Norway">Norway</option>
+                                                <option value="Oman">Oman</option>
+                                                <option value="Pakistan">Pakistan</option>
+                                                <option value="Palau">Palau</option>
+                                                <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+                                                <option value="Panama">Panama</option>
+                                                <option value="Papua New Guinea">Papua New Guinea</option>
+                                                <option value="Paraguay">Paraguay</option>
+                                                <option value="Peru">Peru</option>
+                                                <option value="Philippines">Philippines</option>
+                                                <option value="Pitcairn">Pitcairn</option>
+                                                <option value="Poland">Poland</option>
+                                                <option value="Portugal">Portugal</option>
+                                                <option value="Puerto Rico">Puerto Rico</option>
+                                                <option value="Qatar">Qatar</option>
+                                                <option value="Reunion">Reunion</option>
+                                                <option value="Romania">Romania</option>
+                                                <option value="Russian Federation">Russian Federation</option>
+                                                <option value="Rwanda">Rwanda</option>
+                                                <option value="Saint Helena">Saint Helena</option>
+                                                <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+                                                <option value="Saint Lucia">Saint Lucia</option>
+                                                <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+                                                <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
+                                                <option value="Samoa">Samoa</option>
+                                                <option value="San Marino">San Marino</option>
+                                                <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+                                                <option value="Saudi Arabia">Saudi Arabia</option>
+                                                <option value="Senegal">Senegal</option>
+                                                <option value="Seychelles">Seychelles</option>
+                                                <option value="Sierra Leone">Sierra Leone</option>
+                                                <option value="Singapore">Singapore</option>
+                                                <option value="Slovakia">Slovakia</option>
+                                                <option value="Slovenia">Slovenia</option>
+                                                <option value="Solomon Islands">Solomon Islands</option>
+                                                <option value="Somalia">Somalia</option>
+                                                <option value="South Africa">South Africa</option>
+                                                <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
+                                                <option value="Spain">Spain</option>
+                                                <option value="Sri Lanka">Sri Lanka</option>
+                                                <option value="Sudan">Sudan</option>
+                                                <option value="Suriname">Suriname</option>
+                                                <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+                                                <option value="Swaziland">Swaziland</option>
+                                                <option value="Sweden">Sweden</option>
+                                                <option value="Switzerland">Switzerland</option>
+                                                <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+                                                <option value="Taiwan">Taiwan</option>
+                                                <option value="Tajikistan">Tajikistan</option>
+                                                <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+                                                <option value="Thailand">Thailand</option>
+                                                <option value="Togo">Togo</option>
+                                                <option value="Tokelau">Tokelau</option>
+                                                <option value="Tonga">Tonga</option>
+                                                <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+                                                <option value="Tunisia">Tunisia</option>
+                                                <option value="Turkey">Turkey</option>
+                                                <option value="Turkmenistan">Turkmenistan</option>
+                                                <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+                                                <option value="Tuvalu">Tuvalu</option>
+                                                <option value="Uganda">Uganda</option>
+                                                <option value="Ukraine">Ukraine</option>
+                                                <option value="United Arab Emirates">United Arab Emirates</option>
+                                                <option value="United Kingdom">United Kingdom</option>
+                                                <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+                                                <option value="Uruguay">Uruguay</option>
+                                                <option value="Uzbekistan">Uzbekistan</option>
+                                                <option value="Vanuatu">Vanuatu</option>
+                                                <option value="Venezuela">Venezuela</option>
+                                                <option value="Viet Nam">Viet Nam</option>
+                                                <option value="Virgin Islands, British">Virgin Islands, British</option>
+                                                <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+                                                <option value="Wallis and Futuna">Wallis and Futuna</option>
+                                                <option value="Western Sahara">Western Sahara</option>
+                                                <option value="Yemen">Yemen</option>
+                                                <option value="Yugoslavia">Yugoslavia</option>
+                                                <option value="Zambia">Zambia</option>
+                                                <option value="Zimbabwe">Zimbabwe</option>
+                                                <option value="Unknown">Unknown</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                                <!--END Sole Proprietor Information Form-->
+                                <!--START Owner Address Information Form-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="addressinfo">Owner Address Information</h2>
+                                </div>
+                                <fieldset aria-labelledby="addressinfo">
+                                    <div class="row">
+                                        <div class="form-group form-group-md col-md-12 col-lg-7">
+                                            <label for="OwnerAddressCountry"><span class="weight600">&#42;</span>Country / U.S. territory</label>
+                                            <select class="form-control" id="OwnerAddressCountry" name="territory"  th:field="${owner.country}">
+                                                <option value="">Select</option>
+                                                <option value="United States of America">United States of America</option>
+                                                <option value="Afghanistan">Afghanistan</option>
+                                                <option value="Albania">Albania</option>
+                                                <option value="Algeria">Algeria</option>
+                                                <option value="American Samoa">American Samoa</option>
+                                                <option value="Andorra">Andorra</option>
+                                                <option value="Angola">Angola</option>
+                                                <option value="Anguilla">Anguilla</option>
+                                                <option value="Antarctica">Antarctica</option>
+                                                <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+                                                <option value="Argentina">Argentina</option>
+                                                <option value="Armenia">Armenia</option>
+                                                <option value="Aruba">Aruba</option>
+                                                <option value="Australia">Australia</option>
+                                                <option value="Austria">Austria</option>
+                                                <option value="Azerbaijan">Azerbaijan</option>
+                                                <option value="Bahamas">Bahamas</option>
+                                                <option value="Bahrain">Bahrain</option>
+                                                <option value="Bangladesh">Bangladesh</option>
+                                                <option value="Barbados">Barbados</option>
+                                                <option value="Belarus">Belarus</option>
+                                                <option value="Belgium">Belgium</option>
+                                                <option value="Belize">Belize</option>
+                                                <option value="Benin">Benin</option>
+                                                <option value="Bermuda">Bermuda</option>
+                                                <option value="Bhutan">Bhutan</option>
+                                                <option value="Bolivia">Bolivia</option>
+                                                <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+                                                <option value="Botswana">Botswana</option>
+                                                <option value="Bouvet Island">Bouvet Island</option>
+                                                <option value="Brazil">Brazil</option>
+                                                <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+                                                <option value="Brunei Darussalam">Brunei Darussalam</option>
+                                                <option value="Bulgaria">Bulgaria</option>
+                                                <option value="Burkina Faso">Burkina Faso</option>
+                                                <option value="Burundi">Burundi</option>
+                                                <option value="Canada">Canada</option>
+                                                <option value="Cambodia">Cambodia</option>
+                                                <option value="Cameroon">Cameroon</option>
+                                                <option value="Cape Verde">Cape Verde</option>
+                                                <option value="Cayman Islands">Cayman Islands</option>
+                                                <option value="Central African Republic">Central African Republic</option>
+                                                <option value="Chad">Chad</option>
+                                                <option value="Chile">Chile</option>
+                                                <option value="China">China</option>
+                                                <option value="Christmas Island">Christmas Island</option>
+                                                <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+                                                <option value="Colombia">Colombia</option>
+                                                <option value="Comoros">Comoros</option>
+                                                <option value="Congo">Congo</option>
+                                                <option value="Congo, The Democratic Republic of">Congo, The Democratic Republic of</option>
+                                                <option value="Cook Islands">Cook Islands</option>
+                                                <option value="Costa Rica">Costa Rica</option>
+                                                <option value="Cote D'Ivoire">Cote D&#8217;Ivoire</option>
+                                                <option value="Croatia">Croatia</option>
+                                                <option value="Cuba">Cuba</option>
+                                                <option value="Cyprus">Cyprus</option>
+                                                <option value="Czech Republic">Czech Republic</option>
+                                                <option value="Denmark">Denmark</option>
+                                                <option value="Djibouti">Djibouti</option>
+                                                <option value="Dominica">Dominica</option>
+                                                <option value="Dominican Republic">Dominican Republic</option>
+                                                <option value="East Timor">East Timor</option>
+                                                <option value="Ecuador">Ecuador</option>
+                                                <option value="Egypt">Egypt</option>
+                                                <option value="El Salvador">El Salvador</option>
+                                                <option value="Equatorial Guinea">Equatorial Guinea</option>
+                                                <option value="Eritrea">Eritrea</option>
+                                                <option value="Estonia">Estonia</option>
+                                                <option value="Ethiopia">Ethiopia</option>
+                                                <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+                                                <option value="Faroe Islands">Faroe Islands</option>
+                                                <option value="Fiji">Fiji</option>
+                                                <option value="Finland">Finland</option>
+                                                <option value="France">France</option>
+                                                <option value="French Guiana">French Guiana</option>
+                                                <option value="French Polynesia">French Polynesia</option>
+                                                <option value="French Southern Territories">French Southern Territories</option>
+                                                <option value="Gabon">Gabon</option>
+                                                <option value="Gambia">Gambia</option>
+                                                <option value="Georgia">Georgia</option>
+                                                <option value="Germany">Germany</option>
+                                                <option value="Ghana">Ghana</option>
+                                                <option value="Gibraltar">Gibraltar</option>
+                                                <option value="Greece">Greece</option>
+                                                <option value="Greenland">Greenland</option>
+                                                <option value="Grenada">Grenada</option>
+                                                <option value="Guadeloupe">Guadeloupe</option>
+                                                <option value="Guam">Guam</option>
+                                                <option value="Guatemala">Guatemala</option>
+                                                <option value="Guinea">Guinea</option>
+                                                <option value="Guinea-Bissau">Guinea&#8211;Bissau</option>
+                                                <option value="Guyana">Guyana</option>
+                                                <option value="Haiti">Haiti</option>
+                                                <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+                                                <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+                                                <option value="Honduras">Honduras</option>
+                                                <option value="Hong Kong">Hong Kong</option>
+                                                <option value="Hungary">Hungary</option>
+                                                <option value="Iceland">Iceland</option>
+                                                <option value="India">India</option>
+                                                <option value="Indonesia">Indonesia</option>
+                                                <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+                                                <option value="Iraq">Iraq</option>
+                                                <option value="Ireland">Ireland</option>
+                                                <option value="Israel">Israel</option>
+                                                <option value="Italy">Italy</option>
+                                                <option value="Jamaica">Jamaica</option>
+                                                <option value="Japan">Japan</option>
+                                                <option value="Jordan">Jordan</option>
+                                                <option value="Kazakstan">Kazakstan</option>
+                                                <option value="Kenya">Kenya</option>
+                                                <option value="Kiribati">Kiribati</option>
+                                                <option value="Korea, Democratic People's Republic of">Korea, Democratic People&#8217;S Republic of</option>
+                                                <option value="Korea, Republic of">Korea, Republic of</option>
+                                                <option value="Kuwait">Kuwait</option>
+                                                <option value="Kyrgyzstan">Kyrgyzstan</option>
+                                                <option value="Lao People's Democratic Republic">Lao People&#8217;s Democratic Republic</option>
+                                                <option value="Latvia">Latvia</option>
+                                                <option value="Lebanon">Lebanon</option>
+                                                <option value="Lesotho">Lesotho</option>
+                                                <option value="Liberia">Liberia</option>
+                                                <option value="Libyan Arab Jamahiriya">Libyan Arab Jamahiriya</option>
+                                                <option value="Liechtenstein">Liechtenstein</option>
+                                                <option value="Lithuania">Lithuania</option>
+                                                <option value="Luxembourg">Luxembourg</option>
+                                                <option value="Macau">Macau</option>
+                                                <option value="Macedonia, Former Yugoslav Rep. of">Macedonia, Former Yugoslav Rep. of</option>
+                                                <option value="Madagascar">Madagascar</option>
+                                                <option value="Malawi">Malawi</option>
+                                                <option value="Malaysia">Malaysia</option>
+                                                <option value="Maldives">Maldives</option>
+                                                <option value="Mali">Mali</option>
+                                                <option value="Malta">Malta</option>
+                                                <option value="Marshall Islands">Marshall Islands</option>
+                                                <option value="Martinique">Martinique</option>
+                                                <option value="Mauritania">Mauritania</option>
+                                                <option value="Mauritius">Mauritius</option>
+                                                <option value="Mayotte">Mayotte</option>
+                                                <option value="Mexico">Mexico</option>
+                                                <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+                                                <option value="Moldova, Republic of">Moldova, Republic of</option>
+                                                <option value="Monaco">Monaco</option>
+                                                <option value="Mongolia">Mongolia</option>
+                                                <option value="Montserrat">Montserrat</option>
+                                                <option value="Morocco">Morocco</option>
+                                                <option value="Mozambique">Mozambique</option>
+                                                <option value="Myanmar">Myanmar</option>
+                                                <option value="Namibia">Namibia</option>
+                                                <option value="Nauru">Nauru</option>
+                                                <option value="Nepal">Nepal</option>
+                                                <option value="Netherlands">Netherlands</option>
+                                                <option value="Netherlands Antilles">Netherlands Antilles</option>
+                                                <option value="New Caledonia">New Caledonia</option>
+                                                <option value="New Zealand">New Zealand</option>
+                                                <option value="Nicaragua">Nicaragua</option>
+                                                <option value="Niger">Niger</option>
+                                                <option value="Nigeria">Nigeria</option>
+                                                <option value="Niue">Niue</option>
+                                                <option value="Norfolk Island">Norfolk Island</option>
+                                                <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+                                                <option value="Norway">Norway</option>
+                                                <option value="Oman">Oman</option>
+                                                <option value="Pakistan">Pakistan</option>
+                                                <option value="Palau">Palau</option>
+                                                <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+                                                <option value="Panama">Panama</option>
+                                                <option value="Papua New Guinea">Papua New Guinea</option>
+                                                <option value="Paraguay">Paraguay</option>
+                                                <option value="Peru">Peru</option>
+                                                <option value="Philippines">Philippines</option>
+                                                <option value="Pitcairn">Pitcairn</option>
+                                                <option value="Poland">Poland</option>
+                                                <option value="Portugal">Portugal</option>
+                                                <option value="Puerto Rico">Puerto Rico</option>
+                                                <option value="Qatar">Qatar</option>
+                                                <option value="Reunion">Reunion</option>
+                                                <option value="Romania">Romania</option>
+                                                <option value="Russian Federation">Russian Federation</option>
+                                                <option value="Rwanda">Rwanda</option>
+                                                <option value="Saint Helena">Saint Helena</option>
+                                                <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+                                                <option value="Saint Lucia">Saint Lucia</option>
+                                                <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+                                                <option value="Saint Vincent and the Grenadines">Saint Vincent and the Grenadines</option>
+                                                <option value="Samoa">Samoa</option>
+                                                <option value="San Marino">San Marino</option>
+                                                <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+                                                <option value="Saudi Arabia">Saudi Arabia</option>
+                                                <option value="Senegal">Senegal</option>
+                                                <option value="Seychelles">Seychelles</option>
+                                                <option value="Sierra Leone">Sierra Leone</option>
+                                                <option value="Singapore">Singapore</option>
+                                                <option value="Slovakia">Slovakia</option>
+                                                <option value="Slovenia">Slovenia</option>
+                                                <option value="Solomon Islands">Solomon Islands</option>
+                                                <option value="Somalia">Somalia</option>
+                                                <option value="South Africa">South Africa</option>
+                                                <option value="South Georgia/So. Sandwich Islands">South Georgia/So. Sandwich Islands</option>
+                                                <option value="Spain">Spain</option>
+                                                <option value="Sri Lanka">Sri Lanka</option>
+                                                <option value="Sudan">Sudan</option>
+                                                <option value="Suriname">Suriname</option>
+                                                <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+                                                <option value="Swaziland">Swaziland</option>
+                                                <option value="Sweden">Sweden</option>
+                                                <option value="Switzerland">Switzerland</option>
+                                                <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+                                                <option value="Taiwan">Taiwan</option>
+                                                <option value="Tajikistan">Tajikistan</option>
+                                                <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+                                                <option value="Thailand">Thailand</option>
+                                                <option value="Togo">Togo</option>
+                                                <option value="Tokelau">Tokelau</option>
+                                                <option value="Tonga">Tonga</option>
+                                                <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+                                                <option value="Tunisia">Tunisia</option>
+                                                <option value="Turkey">Turkey</option>
+                                                <option value="Turkmenistan">Turkmenistan</option>
+                                                <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+                                                <option value="Tuvalu">Tuvalu</option>
+                                                <option value="Uganda">Uganda</option>
+                                                <option value="Ukraine">Ukraine</option>
+                                                <option value="United Arab Emirates">United Arab Emirates</option>
+                                                <option value="United Kingdom">United Kingdom</option>
+                                                <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+                                                <option value="Uruguay">Uruguay</option>
+                                                <option value="Uzbekistan">Uzbekistan</option>
+                                                <option value="Vanuatu">Vanuatu</option>
+                                                <option value="Venezuela">Venezuela</option>
+                                                <option value="Viet Nam">Viet Nam</option>
+                                                <option value="Virgin Islands, British">Virgin Islands, British</option>
+                                                <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+                                                <option value="Wallis and Futuna">Wallis and Futuna</option>
+                                                <option value="Western Sahara">Western Sahara</option>
+                                                <option value="Yemen">Yemen</option>
+                                                <option value="Yugoslavia">Yugoslavia</option>
+                                                <option value="Zambia">Zambia</option>
+                                                <option value="Zimbabwe">Zimbabwe</option>
+                                                <option value="Unknown">Unknown</option>
+                                            </select>
+                                        </div>
+                                        <div class="form-group form-group-md col-md-12 col-lg-9">
+                                            <label for="ownerAddress1"><span class="weight600">&#42;</span>Address line 1</label>
+                                            <input type="text" class="form-control" id="ownerAddress1"  th:value="${owner.address1}">
+                                        </div>
+                                        <div class="form-group form-group-md col-md-12 col-lg-9">
+                                            <label for="addressline2">Address line 2</label>
+                                            <input type="text" class="form-control" id="addressline2" >
+                                        </div>
+                                        <div class="form-group form-group-md col-md-12 col-lg-9">
+                                            <label for="addressline3">Address line 3</label>
+                                            <input type="text" class="form-control" id="addressline3" >
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                            <label for="ownerCity"><span class="weight600">&#42;</span>City</label>
+                                            <input type="text" class="form-control" id="ownerCity" th:value="${owner.city}">
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                            <label for="ownerState"><span class="weight600">&#42;</span>State/Province/Territory</label>
+                                            <select class="form-control" id="ownerState" th:field="${owner.state}" required>
+                                                <option value="">Select</option>
+                                                <option value="Alabama">Alabama</option>
+                                                <option value="Alaska">Alaska</option>
+                                                <option value="Arizona">Arizona</option>
+                                                <option value="Arkansas">Arkansas</option>
+                                                <option value="California">California</option>
+                                                <option value="Colorado">Colorado</option>
+                                                <option value="Connecticut">Connecticut</option>
+                                                <option value="Delaware">Delaware</option>
+                                                <option value="District of Columbia">District of Columbia</option>
+                                                <option value="Florida">Florida</option>
+                                                <option value="Georgia">Georgia</option>
+                                                <option value="Hawaii">Hawaii</option>
+                                                <option value="Idaho">Idaho</option>
+                                                <option value="Illinois">Illinois</option>
+                                                <option value="Indiana">Indiana</option>
+                                                <option value="Iowa">Iowa</option>
+                                                <option value="Kansas">Kansas</option>
+                                                <option value="Kentucky">Kentucky</option>
+                                                <option value="Louisiana">Louisiana</option>
+                                                <option value="Maine">Maine</option>
+                                                <option value="Maryland">Maryland</option>
+                                                <option value="Massachusetts">Massachusetts</option>
+                                                <option value="Michigan">Michigan</option>
+                                                <option value="Minnesota">Minnesota</option>
+                                                <option value="Mississippi">Mississippi</option>
+                                                <option value="Missouri">Missouri</option>
+                                                <option value="Montana">Montana</option>
+                                                <option value="Nebraska">Nebraska</option>
+                                                <option value="Nevada">Nevada</option>
+                                                <option value="New Hampshire">New Hampshire</option>
+                                                <option value="New Jersey">New Jersey</option>
+                                                <option value="New Mexico">New Mexico</option>
+                                                <option value="New York">New York</option>
+                                                <option value="North Carolina">North Carolina</option>
+                                                <option value="North Dakota">North Dakota</option>
+                                                <option value="Ohio">Ohio</option>
+                                                <option value="Oklahoma">Oklahoma</option>
+                                                <option value="Oregon">Oregon</option>
+                                                <option value="Pennsylvania">Pennsylvania</option>
+                                                <option value="Rhode Island">Rhode Island</option>
+                                                <option value="South Carolina">South Carolina</option>
+                                                <option value="South Dakota">South Dakota</option>
+                                                <option value="Tennessee">Tennessee</option>
+                                                <option value="Texas">Texas</option>
+                                                <option value="Utah">Utah</option>
+                                                <option value="Vermont">Vermont</option>
+                                                <option value="Virginia">Virginia</option>
+                                                <option value="Washington">Washington</option>
+                                                <option value="West Virginia">West Virginia</option>
+                                                <option value="Wisconsin">Wisconsin</option>
+                                                <option value="Wyoming">Wyoming</option>
+                                            </select>
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-5">
+                                            <label for="ownerZipcode"><span class="weight600">&#42;</span>Zip code/Postal code</label>
+                                            <input type="text" class="form-control" id="ownerZipcode" placeholder="" th:value="${owner.zipcode}">
+                                        </div>
+                                    </div>
+                                </fieldset>
+                                <!--END Owner Address Information Form-->
+                                <!--START Additional Information Form-->
+                                <div class="card-text">
+                                    <h2 class="card-title weight600" id="additionalinfo">Additional Information</h2>
+                                </div>
+                                <fieldset aria-labelledby="additionalinfo">
+                                    <div class="row">
+                                        <div class="form-group form-group-md col-xs-12 col-md-6">
+                                            <label for="ownerEmail"><span class="weight600">&#42;</span>Email address <a href="#" data-toggle="tooltip" title="The USPTO will use this email address to send correspondence regarding this application or registration. It is critical to ensure this email address is current." class="glyphicon glyphicon-info-sign test" data-placement="right"></a></label>
+                                            <input type="text" class="form-control" id="ownerEmail" th:value="${owner.email}">
+                                        </div>
+                                        <div class="form-group form-group-md col-xs-12 col-md-6">
+                                            <label for="webaddress">Website address</label>
+                                            <input type="text" class="form-control" id="webaddress" th:value="${owner.webSiteURL}">
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-xs-12">
+                                                <div class="form-group form-group-md col-xs-12 col-md-4 col-lg-4">
+                                                    <label for="phonenumbertype">Phone type</label>
+                                                    <select class="form-control" id="phonenumbertype" name="phonenumbertype">
+                                                        <option value="Type">Type</option>
+                                                        <option value="Cell">Cell</option>
+                                                        <option value="Home">Home</option>
+                                                        <option value="Work">Work</option>
+                                                        <option value="Fax">Fax</option>
+                                                    </select>
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-md-6 col-lg-6">
+                                                    <label for="phone">Phone number</label>
+                                                    <input type="text" class="form-control" id="phone" th:value="${owner.primaryPhonenumber}">
+                                                </div>
+                                                <div class="form-group form-group-md col-xs-12 col-md-2 col-lg-2">
+                                                    <label for="extension">Ext.</label>
+                                                    <input type="text" class="form-control" id="extension">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                                <div class="inlinebuttons btn-group btn-group-justified  owner-form-buttons" role="navigation" aria-label="view previous or next page" id="prevnxt">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm btn-primary fill next" id="doneButton" value="next" >Done
+                                            <div class="round"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+                                            </div>
+                                        </button>
                                     </div>
                                 </div>
-                            </div>
-                        </fieldset>
-                        <div class="inlinebuttons btn-group btn-group-justified  owner-form-buttons" role="navigation" aria-label="view previous or next page" id="prevnxt">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm btn-primary fill next" id="doneButton" value="next" >Done
-                                    <div class="round"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
-                                    </div>
-                                </button>
-                            </div>
+                                <!--END Additional Information Form-->
+                            </div><!--END Content Div-->
                         </div>
-                        <!--END Additional Information Form-->
-                    </div><!--END Content Div-->
+                    </div><!--END container div-->
                 </div>
-            </div><!--END container div-->
+            </main>
         </div>
-    </main>
-</div>
+    </div>
 
 <!--load model attribute for Jquery consumption  -->
 <script th:inline="javascript">

--- a/PTO-WEB/src/main/resources/templates/application/owner/trust/ownerInfo.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/trust/ownerInfo.html
@@ -29,7 +29,7 @@
                                 <input type="text" class="form-control"  id="ownername" th:field="*{ownerName}" required>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                <label for="stateoforg">State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                <label for="stateoforg">State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                 <select class="form-control" id="stateoforg" th:field="*{ownerOrganizationState}" required>
                                     <option value="">Select</option>
                                     <option value="Alabama">Alabama</option>
@@ -87,7 +87,7 @@
                                 </select>
                             </div>
                             <div class="form-group form-group-md col-xs-12 col-sm-6">
-                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                 <select class="form-control" id="additional-name-type" th:field="*{ownerType}">
                                     <option value="Select">Select</option>
                                     <option value="DBA">Doing Business As (DBA)</option>
@@ -144,7 +144,8 @@
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
                                     <label for="partner-citizenship">Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select th:field="*{partnerDTOs[__${itemStat.index}__].citizenShip}" id="partner-citizenship"  class="form-control" name="owner-citizenship">
-                                        Owner Name
+                                        <option value="">Select</option>
+                                        <option value="United States of America" selected>United States of America</option>
                                     </select>
                                 </div>
                             </div>
@@ -156,7 +157,7 @@
                                     <input id="partner-owner-name" type="text" th:field="*{partnerDTOs[__${itemStat.index}__].partnerName}"  class="form-control rounded-borders" required>
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label>State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label>State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select id="partner-owner-name-state" th:field="*{partnerDTOs[__${itemStat.index}__].state}"  class="form-control" name="State"  required>
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>
@@ -266,7 +267,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input class="form-control" id="partner-suffix2" name="suffix" th:field="*{partner_suffix2}" />
+                                    <input type="text" class="form-control" id="partner-suffix2" name="suffix" th:field="*{partner_suffix2}" />
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
                                     <label for="partner-citizenship">Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
@@ -524,7 +525,7 @@
                                     <input id="partner-owner-name2" type="text"  class="form-control rounded-borders" th:field="*{partner_name2}"  >
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label>State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label>State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select id="partner-owner-name-state2" class="form-control" name="State" th:field="*{partner_state_org2}"  >
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>
@@ -633,7 +634,7 @@
                                 </div>
                                 <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                     <label for="partner-suffix">Suffix</label>
-                                    <input class="form-control" id="partner-suffix3" name="suffix" th:field="*{partner_suffix3}" />
+                                    <input type="text" class="form-control" id="partner-suffix3" name="suffix" th:field="*{partner_suffix3}" />
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
                                     <label for="partner-citizenship">Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
@@ -890,7 +891,7 @@
                                     <input id="partner-owner-name3" type="text" class="form-control rounded-borders" th:field="*{partner_name3}"  >
                                 </div>
                                 <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
-                                    <label>State where legally organized <span class="label label-info subtle visuallyremoved" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                    <label>State where legally organized <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                     <select id="partner-owner-name-state3" class="form-control" name="State" th:field="*{partner_state_org3}" >
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>

--- a/PTO-WEB/src/main/resources/templates/application/owner/trust/ownerInfoEdit.html
+++ b/PTO-WEB/src/main/resources/templates/application/owner/trust/ownerInfoEdit.html
@@ -6,7 +6,8 @@
     <title>Owner Information</title>
 </head>
 <body>
-<div class="row content"  style="display: none;">
+    <div class="container-fluid">
+        <div class="row content"  style="display: none;">
     <main class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
         <div class="row" >
             <div class="col-xs-12">
@@ -95,12 +96,12 @@
 
                         <fieldset aria-labelledby="ownerinfo">
                             <div class="row">
-                                <div class="form-group form-group-md col-xs-6">
+                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
                                     <label for="ownername"><span class="weight600">&#42;</span>Owner name</label>
                                     <input type="text" class="form-control"  id="ownername"  th:value="${owner.ownerDisplayname}">
                                 </div>
-                                <div class="form-group form-group-md col-xs-6">
-                                    <label for="stateoforg"><span class="weight600">&#42;</span>State where legally organized <span class="label label-info subtle visuallyremoved">Reduced Fee</span></label>
+                                <div class="form-group form-group-md col-xs-12 col-sm-9 col-md-6">
+                                    <label for="stateoforg">State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
                                     <select class="form-control" id="stateoforg"  th:field="${owner.ownerOrganizationState}" >
                                         <option value="">Select</option>
                                         <option value="Alabama">Alabama</option>
@@ -156,8 +157,8 @@
                                         <option value="Wyoming">Wyoming</option>
                                     </select>
                                 </div>
-                                <div class="form-group form-group-md col-xs-12 col-sm-6 col-lg-4">
-                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing bsiness as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
+                                <div class="form-group form-group-md col-xs-12 col-sm-6">
+                                    <label for="additional-name-type">Alternate name <a href="#" data-toggle="tooltip" title="Make selection below if the owner is doing business as or trading under a different name." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> </label>
                                     <select class="form-control" id="additional-name-type" th:field="${owner.ownerType}">
                                         <option value="Select">Select</option>
                                         <option value="DBA">Doing Business As (DBA)</option>
@@ -168,14 +169,14 @@
                                 </div>
 
                                 <th:block  th:if="${owner.isAlternameSet() == true}">
-                                    <div class="form-group form-group-md col-xs-12 col-sm-6 col-lg-4" id="nametype">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype">
                                         <label for="nameoftype">Name</label>
                                         <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
                                     </div>
                                 </th:block>
 
                                 <th:block  th:if="${owner.isAlternameSet() == false}">
-                                    <div class="form-group form-group-md col-xs-12 col-sm-6 col-lg-4" id="nametype" style="display: none;">
+                                    <div class="form-group form-group-md col-xs-12 col-sm-6" id="nametype" style="display: none;">
                                         <label for="nameoftype">Name</label>
                                         <input type="text" class="form-control" id="nameoftype" name="nameoftype"  th:value="${owner.ownerAdditionalName}"  ><!--needs th:attribute-->
                                     </div>
@@ -209,12 +210,12 @@
                                             <label ><span class="weight600">&#42;</span>Last name</label>
                                             <input  type="text" name="lastName" class="form-control ge-last-name" th:value="${exceuter.lastName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
                                         </div>
-                                        <div class="form-group form-group-md col-xs-6">
+                                        <div class="form-group form-group-md col-xs-6 col-sm-4 col-md-6">
                                             <label>Suffix</label>
-                                            <input class="form-control ge-suffix" name="suffix" />
+                                            <input type="text" class="form-control ge-suffix" name="suffix" />
                                         </div>
-                                        <div class="form-group form-group-md col-xs-6">
-                                            <label><span class="weight600">&#42;</span>Country of citizenship</label>
+                                        <div class="form-group form-group-md col-xs-12 col-sm-8 col-md-6">
+                                            <label>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
                                             <select class="form-control ge-citizenship" name="owner-citizenship"  th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
                                                 <option th:value="${exceuter.entityCitizenship}" th:text="${exceuter.entityCitizenship}" selected th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}"></option>
                                                 <option value="">Select</option>
@@ -467,7 +468,7 @@
                                             <input  type="text" class="form-control rounded-borders ge-name" style="" th:value="${exceuter.entityName}" th:attr="entity-id=${exceuter.id}, entity-index=${iter.index}">
                                         </div>
                                         <div class="form-group form-group-md col-xs-6">
-                                            <label><span class="weight600">&#42;</span>State where legally organized</label>
+                                            <label>State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
                                             <select class="form-control ge-state" name="State" th:attr="entity-index=${iter.index}" >
                                                 <option th:value="${exceuter.organizationState}"  th:text="${exceuter.organizationState}"  th:attr="entity-id=${exceuter.id}"selected></option>
                                                 <option value="">Select</option>
@@ -582,11 +583,11 @@
                                             </div>
                                             <div class="form-group form-group-md col-xs-6">
                                                 <label for="partner-suffix">Suffix</label>
-                                                <input class="form-control" id="partner-suffix" value="">
+                                                <input type="text" class="form-control" id="partner-suffix" value="">
                                             </div>
                                             <div class="form-group form-group-md col-xs-6">
-                                                <label><span class="weight600">&#42;</span>Country of citizenship</label>
-                                                <select class="form-control ge-citizenship" required="">
+                                                <label>Country of citizenship <a href="#" data-toggle="tooltip" title="If you have dual citizenship only enter the citizenship you would like printed in the Official Gazette." class="glyphicon glyphicon-info-sign test" data-placement="right"></a> <span class="label label-info subtle" aria-describedby="#costsavingoptions">Reduced Fee</span></label>
+                                                <select class="form-control ge-citizenship">
                                                     <option value="">Select</option>
                                                     <option value="United States of America">United States of America</option>
                                                     <option value="Afghanistan">Afghanistan</option>
@@ -839,7 +840,7 @@
                                                 <input type="text" class="form-control rounded-borders ge-name"  required  value="">
                                             </div>
                                             <div class="form-group form-group-md col-xs-6">
-                                                <label><span class="weight600">&#42;</span>State where legally organized</label>
+                                                <label>State where legally organized <span class="label label-info subtle">Reduced Fee</span></label>
                                                 <select  class="form-control ge-state">
                                                     <option value="">Select</option>
                                                     <option value="Alabama">Alabama</option>
@@ -1315,6 +1316,7 @@
         </div>
     </main>
 </div>
+    </div>
 
 <!--load model attribute for Jquery consumption  -->
 <script th:inline="javascript">


### PR DESCRIPTION
-- Added Tooltip + TEAS+
-- Removed visuallyremoved class from TEAS tags
-- col- class adjustments for colliding inputs/labels
-- ‘State of Org’ to ‘State where legally organized’ label update
-- Owner Info > Trust > Country of citizenship picklist fix (needs proper option content)
-- Fix for styling of Un-do Add Partner Buttons
-- Fixed red asterisks
-- Removed required astericks and HTML ‘required’ attribute from State where legally organized + Country of Citizenship, accept not from State where legally organized > LLC per JB
-- Added type=‘text’ attribute to Suffix input to effect its height
-- Fix for full-bleed (to edge of screen) issue at min screen widths